### PR TITLE
Add complex Pascal test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Agent Instructions
+
+This repository contains a Pascal compiler implemented in **C++23**. A simple **Makefile** builds sources and runs tests.
+
+## Workflow
+
+1. **Format** all C++ files with `clang-format` if available:
+   ```bash
+   clang-format -i src/**/*.cpp include/**/*.hpp
+   ```
+2. Build the compiler:
+   ```bash
+   make compiler
+   ```
+3. Run tests with:
+   ```bash
+   make tests
+   ```
+   If tests fail due to missing dependencies or environment restrictions, mention this in the PR description.
+4. Make small, focused commits using the prefixes `feat:`, `fix:`, `style:` or `chore:`.
+5. Pull request summaries must describe key changes and cite updated files. Include test output in the testing section.
+
+## Code Style
+
+- Use clear comments and keep lines under 80 characters when possible.
+- Organize sources under `src` and headers under `include`.
+- Remove unused code and keep the repository clean of build artefacts.
+
+## Build System
+
+- Only the provided **Makefile** should be used. It defines the `all`,
+  `compiler`, `tests`, and `clean` rules.
+- Place compiled binaries in the `build/` directory.
+
+## AGENTS.md Inheritance
+
+- This file governs the entire repository.
+- Nested `AGENTS.md` files may override these instructions for their
+  directory subtree.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+CXX ?= g++
+MODE ?= debug
+
+WARN = -Werror -Wall -Wextra -Wpedantic -Wformat=2 -Wshadow -Wwrite-strings \
+       -Wcast-qual -Wcast-align -Wconversion -Wno-switch \
+       -Wno-ignored-optimization-argument
+ifeq ($(CXX),clang++)
+WARN += -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic \
+        -Wno-c++20-compat -Wno-c++20-extensions -Wno-c99-extensions \
+        -Wno-zero-as-null-pointer-constant -Wno-padded \
+        -Wno-global-constructors -Wno-exit-time-destructors \
+        -Wno-unused-macros
+else ifeq ($(CXX),g++)
+WARN += -fconcepts-diagnostics-depth=3
+endif
+
+SANITIZE = -fsanitize=address,undefined -fsanitize-address-use-after-scope
+ifeq ($(MODE),release)
+OPT = -O3
+else
+OPT = -ggdb3 -O0 $(SANITIZE)
+endif
+
+CXXFLAGS = -std=c++23 $(WARN) $(OPT) -Iinclude -Isrc
+SRC_ALL = $(wildcard src/*.cpp src/token/*.cpp src/scanner/*.cpp \
+                       src/parser/*.cpp src/visitors/*.cpp)
+SRC = $(SRC_ALL)
+SRC_TEST = $(filter-out src/main.cpp,$(SRC_ALL))
+TEST_SRC = $(wildcard tests/*.cpp)
+BUILD_DIR = build
+TARGET = $(BUILD_DIR)/compiler
+TEST_BIN = $(BUILD_DIR)/tests
+
+all: compiler
+
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+compiler: $(TARGET)
+
+$(TARGET): $(SRC) | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) $(SRC) -o $(TARGET)
+
+.PHONY: tests clean
+
+tests: $(TEST_BIN)
+
+$(TEST_BIN): $(TEST_SRC) $(SRC_TEST) | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) $(TEST_SRC) $(SRC_TEST) -lgtest -lgtest_main -lpthread -o $(TEST_BIN)
+	cd tests && ./run_tests.sh
+
+clean:
+	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -1,19 +1,4 @@
-# C++ Template
-Generic C++ template with automatic instalation of Raylib, SpdLog & CTest.
+# Pascal Compiler
 
-
-## Raylib
-
-[required libraries](https://github.com/raysan5/raylib/wiki/Working-on-GNU-Linux#install-required-libraries)
-
-
-## Recomended tools
-This tools are used as part of the pre-commit tests, they can be disabled by editing `.pre-commit-config.yaml` (or `CMakeLists.txt` in the case of [IWYU](https://github.com/include-what-you-use/include-what-you-use?tab=readme-ov-file#using-with-cmake))
-
-- clang-format
-- clang-tidy
-- cppcheck
-- cpplint
-- include-what-you-use
-- commitizen
-  commit message standarizer
+This repository contains an initial structure for a Pascal compiler written in C++23.
+See `docs/README.md` for full instructions and project goals.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,111 @@
+# Pascal Compiler
+
+This project implements a simple Pascal compiler written in C++23. The goal
+is to support core Pascal syntax and several extensions such as floating point
+numbers, unsigned integers, `longint`, dynamic memory handling, strings, arrays,
+structures, and pointers.
+
+## Compiling
+
+Use the provided `Makefile` with a C++23 compiler. Set `CXX` to `g++`
+or `clang++` as needed (g++ is the default).
+```bash
+make        # builds the compiler
+make tests  # runs example tests
+make clean  # removes build artefacts
+```
+
+The resulting binary is placed in `build/compiler`.
+
+## Using the Compiler
+
+Once built, invoke the compiler with a Pascal source file:
+
+```bash
+./build/compiler my_program.pas
+```
+
+The compiler currently outputs a placeholder message and can be extended to
+generate assembly.
+
+## Pascal Grammar
+
+```ebnf
+program        = 'program' identifier ';' block '.' ;
+block          = declaration_part 'begin' statement_list 'end' ;
+declaration_part = { const_section | type_section | var_section | routine_decl } ;
+const_section  = 'const' const_def { const_def } ;
+const_def      = identifier '=' constant ';' ;
+type_section   = 'type' type_def { type_def } ;
+type_def       = identifier '=' type_spec ';' ;
+var_section    = 'var' var_decl { var_decl } ;
+var_decl       = identifier_list ':' type_spec ';' ;
+routine_decl   = procedure_decl | function_decl ;
+procedure_decl = 'procedure' identifier param_list? ';' block ';' ;
+function_decl  = 'function' identifier param_list? ':' type_spec ';' block ';' ;
+param_list     = '(' param_decl { ';' param_decl } ')' ;
+param_decl     = identifier_list ':' type_spec ;
+identifier_list = identifier { ',' identifier } ;
+type_spec      = simple_type | array_type | record_type | pointer_type ;
+simple_type    = 'integer' | 'longint' | 'unsigned' | 'real' | 'string' | identifier ;
+array_type     = 'array' '[' range ']' 'of' type_spec ;
+range          = number '..' number ;
+record_type    = 'record' var_decl { var_decl } 'end' ;
+pointer_type   = '^' type_spec ;
+statement_list = statement { ';' statement } ;
+statement      = assignment | procedure_call | compound
+                 | if_stmt | while_stmt | for_stmt
+                 | repeat_stmt | case_stmt | with_stmt ;
+compound       = 'begin' statement_list 'end' ;
+assignment     = variable ':=' expression ;
+procedure_call = identifier '(' expression_list? ')' ;
+if_stmt        = 'if' expression 'then' statement [ 'else' statement ] ;
+while_stmt     = 'while' expression 'do' statement ;
+for_stmt       = 'for' assignment 'to' expression 'do' statement ;
+repeat_stmt    = 'repeat' statement_list 'until' expression ;
+case_stmt      = 'case' expression 'of' case_list 'end' ;
+case_list      = case_label ':' statement { ';' case_label ':' statement } ;
+case_label     = constant { ',' constant } ;
+with_stmt      = 'with' variable 'do' statement ;
+expression_list= expression { ',' expression } ;
+expression     = simple_expression [ relop simple_expression ] ;
+simple_expression = term { addop term } ;
+term           = factor { mulop factor } ;
+factor         = variable | number | string | '(' expression ')'
+                 | 'not' factor | 'new' '(' variable ')'
+                 | 'dispose' '(' variable ')' ;
+variable       = identifier { selector } ;
+selector       = '.' identifier | '[' expression ']' | '^' ;
+addop          = '+' | '-' | 'or' ;
+mulop          = '*' | '/' | 'div' | 'mod' | 'and' ;
+relop          = '=' | '<>' | '<' | '<=' | '>' | '>=' ;
+```
+
+## Extensions
+
+- **float** – support for real numbers with decimal points.
+- **unsigned int** – ability to declare unsigned integer types.
+- **longint** – 32‑bit signed integers.
+- **dynamic memory** – `new` and `dispose` for pointer management.
+- **strings** – native string type handling.
+- **arrays** – fixed length array declarations and indexing.
+- **struct** – record types to group fields.
+- **pointers** – pointer types and dereferencing.
+
+## Example
+
+```
+program Hello;
+begin
+  writeln('Hello, world!');
+end.
+```
+
+The resulting (example) assembly might look like:
+
+```
+section .text
+  global _start
+_start:
+  ; print message
+```

--- a/include/parser/parser.hpp
+++ b/include/parser/parser.hpp
@@ -1,0 +1,20 @@
+#ifndef PASCAL_COMPILER_PARSER_HPP
+#define PASCAL_COMPILER_PARSER_HPP
+
+#include "token/token.hpp"
+#include <vector>
+
+namespace pascal {
+
+class Parser {
+public:
+  explicit Parser(const std::vector<Token> &tokens);
+  void parse();
+
+private:
+  const std::vector<Token> &m_tokens;
+};
+
+} // namespace pascal
+
+#endif // PASCAL_COMPILER_PARSER_HPP

--- a/include/scanner/lexer.hpp
+++ b/include/scanner/lexer.hpp
@@ -1,0 +1,21 @@
+#ifndef PASCAL_COMPILER_LEXER_HPP
+#define PASCAL_COMPILER_LEXER_HPP
+
+#include "token/token.hpp"
+#include <string_view>
+#include <vector>
+
+namespace pascal {
+
+class Lexer {
+public:
+  explicit Lexer(std::string_view source);
+  std::vector<Token> scanTokens();
+
+private:
+  std::string_view m_source;
+};
+
+} // namespace pascal
+
+#endif // PASCAL_COMPILER_LEXER_HPP

--- a/include/token/token.hpp
+++ b/include/token/token.hpp
@@ -1,0 +1,17 @@
+#ifndef PASCAL_COMPILER_TOKENS_HPP
+#define PASCAL_COMPILER_TOKENS_HPP
+
+#include <string>
+
+namespace pascal {
+
+enum class TokenType { Identifier, Number, String, EndOfFile };
+
+struct Token {
+  TokenType type;
+  std::string lexeme;
+};
+
+} // namespace pascal
+
+#endif // PASCAL_COMPILER_TOKENS_HPP

--- a/include/token/types.hpp
+++ b/include/token/types.hpp
@@ -1,0 +1,16 @@
+#ifndef PASCAL_COMPILER_TYPES_HPP
+#define PASCAL_COMPILER_TYPES_HPP
+
+namespace pascal {
+
+enum class BasicType {
+  Integer,
+  LongInt,
+  UnsignedInt,
+  Real,
+  String,
+};
+
+} // namespace pascal
+
+#endif // PASCAL_COMPILER_TYPES_HPP

--- a/include/visitors/codegen.hpp
+++ b/include/visitors/codegen.hpp
@@ -1,0 +1,13 @@
+#ifndef PASCAL_COMPILER_CODEGEN_HPP
+#define PASCAL_COMPILER_CODEGEN_HPP
+
+namespace pascal {
+
+class CodeGenerator {
+public:
+  void generate();
+};
+
+} // namespace pascal
+
+#endif // PASCAL_COMPILER_CODEGEN_HPP

--- a/include/visitors/memory.hpp
+++ b/include/visitors/memory.hpp
@@ -1,0 +1,14 @@
+#ifndef PASCAL_COMPILER_MEMORY_HPP
+#define PASCAL_COMPILER_MEMORY_HPP
+
+namespace pascal {
+
+class MemoryManager {
+public:
+  void allocate();
+  void deallocate();
+};
+
+} // namespace pascal
+
+#endif // PASCAL_COMPILER_MEMORY_HPP

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,57 +1,9 @@
-#include "utils.hpp"
+#include "parser/parser.hpp"
+#include "scanner/lexer.hpp"
+#include "visitors/codegen.hpp"
 #include <iostream>
-// #include <Texture.hpp>
-// #include <Window.hpp>
-// #include <raylib.h>
 
-#if defined(_WIN32)
-#define NOGDI  // All GDI defines and routines
-#define NOUSER // All USER defines and routines
-#endif
-
-// #include <spdlog/spdlog.h>
-
-#if defined(_WIN32) // raylib uses these names as function parameters
-#undef near
-#undef far
-#endif
-
-// constexpr int TARGET_FPS = 60;
-
-auto main() -> int {
-
-  // constexpr int SCREEN_WIDTH = 800;
-  // constexpr int SCREEN_HEIGHT = 450;
-  //
-  // constexpr int TEXT_X_POS = 190;
-  // constexpr int TEXT_Y_POS = 200;
-  // constexpr int TEXT_FONT_SIZE = 20;
-  std::cout << "Hello, World!" << std::endl;
-
-  // raylib::Window window(SCREEN_WIDTH, SCREEN_HEIGHT,
-  //                       "raylib-cpp - basic window");
-  // raylib::Texture logo(ASSETS_PATH "dogo.png");
-  //
-  // SetTargetFPS(TARGET_FPS);
-  //
-  // spdlog::info("Started drawing");
-  //
-  // while (!window.ShouldClose()) {
-  //   BeginDrawing();
-  //
-  //   window.ClearBackground(RAYWHITE);
-  //
-  //   // Object methods.
-  //   logo.Draw(SCREEN_WIDTH / 2 - logo.GetWidth() / 2,
-  //             SCREEN_HEIGHT / 2 - logo.GetHeight() / 2);
-  //
-  //   DrawText("Congrats! You created your first window!", TEXT_X_POS,
-  //   TEXT_Y_POS,
-  //            TEXT_FONT_SIZE, LIGHTGRAY);
-  //
-  //   EndDrawing();
-  // }
-  // spdlog::info("Finished drawing");
-
+int main(int /*argc*/, char ** /*argv*/) {
+  std::cout << "Pascal compiler (C++23) stub" << std::endl;
   return 0;
 }

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -1,0 +1,9 @@
+#include "parser/parser.hpp"
+
+namespace pascal {
+
+Parser::Parser(const std::vector<Token> &tokens) : m_tokens(tokens) {}
+
+void Parser::parse() {}
+
+} // namespace pascal

--- a/src/scanner/lexer.cpp
+++ b/src/scanner/lexer.cpp
@@ -1,0 +1,9 @@
+#include "scanner/lexer.hpp"
+
+namespace pascal {
+
+Lexer::Lexer(std::string_view source) : m_source(source) {}
+
+std::vector<Token> Lexer::scanTokens() { return {}; }
+
+} // namespace pascal

--- a/src/visitors/codegen.cpp
+++ b/src/visitors/codegen.cpp
@@ -1,0 +1,7 @@
+#include "visitors/codegen.hpp"
+
+namespace pascal {
+
+void CodeGenerator::generate() {}
+
+} // namespace pascal

--- a/src/visitors/memory.cpp
+++ b/src/visitors/memory.cpp
@@ -1,0 +1,9 @@
+#include "visitors/memory.hpp"
+
+namespace pascal {
+
+void MemoryManager::allocate() {}
+
+void MemoryManager::deallocate() {}
+
+} // namespace pascal

--- a/tests/compiler_tests.cpp
+++ b/tests/compiler_tests.cpp
@@ -1,0 +1,104 @@
+#include "parser/parser.hpp"
+#include "scanner/lexer.hpp"
+#include <gtest/gtest.h>
+
+using pascal::Lexer;
+using pascal::Parser;
+
+static void run_no_throw(std::string_view src) {
+  Lexer lex(src);
+  auto tokens = lex.scanTokens();
+  Parser parser(tokens);
+  EXPECT_NO_THROW(parser.parse());
+}
+
+// Variable declarations
+TEST(VarDeclTests, Decl1) { run_no_throw("var a: integer;"); }
+TEST(VarDeclTests, Decl2) { run_no_throw("var b: real;"); }
+TEST(VarDeclTests, Decl3) { run_no_throw("var c: unsigned;"); }
+
+// Expressions
+TEST(ExpressionTests, Expr1) { run_no_throw("begin a := 1; end."); }
+TEST(ExpressionTests, Expr2) { run_no_throw("begin b := a + 1; end."); }
+TEST(ExpressionTests, Expr3) { run_no_throw("begin c := b * 2; end."); }
+
+// Control statements
+TEST(ControlTests, IfStmt) { run_no_throw("if a > 0 then b := 1;"); }
+TEST(ControlTests, IfElse) {
+  run_no_throw("if a > 0 then b := 1 else b := 2;");
+}
+TEST(ControlTests, CaseStmt) { run_no_throw("case a of 1: b := 1; end;"); }
+TEST(ControlTests, WhileStmt) { run_no_throw("while a > 0 do a := a - 1;"); }
+TEST(ControlTests, ForStmt) { run_no_throw("for i:=1 to 10 do a:=i;"); }
+TEST(ControlTests, RepeatStmt) { run_no_throw("repeat a:=a-1 until a=0;"); }
+
+// Functions
+TEST(FunctionTests, Func1) {
+  run_no_throw("function f: integer; begin f:=0; end;");
+}
+TEST(FunctionTests, Func2) { run_no_throw("procedure p; begin end;"); }
+TEST(FunctionTests, Func3) {
+  run_no_throw("function g(x: integer): integer; begin g:=x; end;");
+}
+
+// Float
+TEST(FloatTests, Float1) { run_no_throw("var x: real; x:=1.0;"); }
+TEST(FloatTests, Float2) { run_no_throw("x:=1.5+2.5;"); }
+TEST(FloatTests, Float3) { run_no_throw("if 0.0 < 1.0 then x:=0.0;"); }
+TEST(FloatTests, Float4) { run_no_throw("while x < 1.0 do x:=x+0.1;"); }
+TEST(FloatTests, Float5) {
+  run_no_throw("function f: real; begin f:=0.0; end;");
+}
+
+// Unsigned int
+TEST(UnsignedTests, Uns1) { run_no_throw("var u: unsigned;"); }
+TEST(UnsignedTests, Uns2) { run_no_throw("u:=1;"); }
+TEST(UnsignedTests, Uns3) { run_no_throw("while u>0 do u:=u-1;"); }
+TEST(UnsignedTests, Uns4) {
+  run_no_throw("function f: unsigned; begin f:=0; end;");
+}
+TEST(UnsignedTests, Uns5) { run_no_throw("for u:=1 to 5 do u:=u;"); }
+
+// Long int
+TEST(LongIntTests, Long1) { run_no_throw("var l: longint;"); }
+TEST(LongIntTests, Long2) { run_no_throw("l:=1;"); }
+TEST(LongIntTests, Long3) { run_no_throw("while l>0 do l:=l-1;"); }
+TEST(LongIntTests, Long4) {
+  run_no_throw("function f: longint; begin f:=0; end;");
+}
+TEST(LongIntTests, Long5) { run_no_throw("for l:=1 to 5 do l:=l;"); }
+
+// Dynamic memory
+TEST(DynamicTests, Dyn1) { run_no_throw("new(p);"); }
+TEST(DynamicTests, Dyn2) { run_no_throw("dispose(p);"); }
+TEST(DynamicTests, Dyn3) { run_no_throw("var p:^integer;"); }
+TEST(DynamicTests, Dyn4) { run_no_throw("p^:=1;"); }
+TEST(DynamicTests, Dyn5) { run_no_throw("if p<>nil then dispose(p);"); }
+
+// Strings
+TEST(StringTests, Str1) { run_no_throw("var s: string;"); }
+TEST(StringTests, Str2) { run_no_throw("s:='hi';"); }
+TEST(StringTests, Str3) { run_no_throw("s:=s+'!';"); }
+TEST(StringTests, Str4) { run_no_throw("writeln(s);"); }
+TEST(StringTests, Str5) { run_no_throw("if s='' then s:='a';"); }
+
+// Arrays
+TEST(ArrayTests, Arr1) { run_no_throw("var a: array[1..5] of integer;"); }
+TEST(ArrayTests, Arr2) { run_no_throw("a[1]:=0;"); }
+TEST(ArrayTests, Arr3) { run_no_throw("for i:=1 to 5 do a[i]:=i;"); }
+TEST(ArrayTests, Arr4) { run_no_throw("writeln(a[1]);"); }
+TEST(ArrayTests, Arr5) { run_no_throw("if a[1]=0 then a[1]:=1;"); }
+
+// Struct (record)
+TEST(StructTests, Rec1) { run_no_throw("type r=record a:integer; end;"); }
+TEST(StructTests, Rec2) { run_no_throw("var v:r;"); }
+TEST(StructTests, Rec3) { run_no_throw("v.a:=1;"); }
+TEST(StructTests, Rec4) { run_no_throw("with v do a:=2;"); }
+TEST(StructTests, Rec5) { run_no_throw("if v.a=0 then v.a:=1;"); }
+
+// Pointers
+TEST(PointerTests, Ptr1) { run_no_throw("var p:^integer;"); }
+TEST(PointerTests, Ptr2) { run_no_throw("new(p);"); }
+TEST(PointerTests, Ptr3) { run_no_throw("p^:=1;"); }
+TEST(PointerTests, Ptr4) { run_no_throw("dispose(p);"); }
+TEST(PointerTests, Ptr5) { run_no_throw("p:=nil;"); }

--- a/tests/complex_tests.cpp
+++ b/tests/complex_tests.cpp
@@ -1,0 +1,205 @@
+#include "parser/parser.hpp"
+#include "scanner/lexer.hpp"
+#include <gtest/gtest.h>
+
+using pascal::Lexer;
+using pascal::Parser;
+
+static void run_no_throw(std::string_view src) {
+  Lexer lex(src);
+  auto tokens = lex.scanTokens();
+  Parser parser(tokens);
+  EXPECT_NO_THROW(parser.parse());
+}
+
+TEST(ComplexTests, FibonacciArray) {
+  run_no_throw(R"(
+program Fib;
+var i: longint; f: array[1..10] of longint;
+begin
+  f[1]:=1; f[2]:=1;
+  for i:=3 to 10 do
+    f[i]:=f[i-1]+f[i-2];
+end.)");
+}
+
+TEST(ComplexTests, FactorialUnsigned) {
+  run_no_throw(R"(
+function fact(n: unsigned): unsigned;
+begin
+  if n=0 then fact:=1
+  else fact:=n*fact(n-1);
+end;
+begin
+  fact(5);
+end.)");
+}
+
+TEST(ComplexTests, RecordPointer) {
+  run_no_throw(R"(
+type pr = ^rec;
+     rec = record val: longint; next: pr; end;
+var p: pr;
+begin
+  new(p); p^.val:=1; dispose(p);
+end.)");
+}
+
+TEST(ComplexTests, StringConcat) {
+  run_no_throw(R"(
+var s: string;
+begin
+  s:='Hello';
+  s:=s+' World';
+end.)");
+}
+
+TEST(ComplexTests, FloatArray) {
+  run_no_throw(R"(
+var a: array[1..3] of real; i: integer;
+begin
+  a[1]:=1.1; a[2]:=2.2; a[3]:=3.3;
+  for i:=1 to 3 do a[i]:=a[i]*2.0;
+end.)");
+}
+
+TEST(ComplexTests, PointerRecord) {
+  run_no_throw(R"(
+type r = record x: integer; end;
+var p:^r;
+begin
+  new(p); p^.x:=5; dispose(p);
+end.)");
+}
+
+TEST(ComplexTests, MatrixLongint) {
+  run_no_throw(R"(
+var m: array[1..2,1..2] of longint;
+begin
+  m[1,1]:=1; m[1,2]:=2;
+  m[2,1]:=3; m[2,2]:=4;
+end.)");
+}
+
+TEST(ComplexTests, LinkedList) {
+  run_no_throw(R"(
+type nodep = ^node;
+     node = record val: longint; next: nodep; end;
+var head,node1: nodep;
+begin
+  new(head); new(node1);
+  head^.next:=node1; node1^.next:=nil;
+end.)");
+}
+
+TEST(ComplexTests, DynamicFloatArray) {
+  run_no_throw(R"(
+type arrp = ^array[1..5] of real;
+var p: arrp;
+begin
+  new(p); p^[1]:=1.0; dispose(p);
+end.)");
+}
+
+TEST(ComplexTests, SortLongint) {
+  run_no_throw(R"(
+var a: array[1..3] of longint; i,j,t: longint;
+begin
+  for i:=1 to 2 do
+    for j:=i+1 to 3 do
+      if a[i]>a[j] then
+        begin t:=a[i]; a[i]:=a[j]; a[j]:=t; end;
+end.)");
+}
+
+TEST(ComplexTests, ArrayOfStrings) {
+  run_no_throw(R"(
+var names: array[1..2] of string;
+begin
+  names[1]:='Alice';
+  names[2]:='Bob';
+end.)");
+}
+
+TEST(ComplexTests, PointerRecordString) {
+  run_no_throw(R"(
+type person = record name: string; end;
+var p:^person;
+begin
+  new(p); p^.name:='Ana'; dispose(p);
+end.)");
+}
+
+TEST(ComplexTests, NestedRecordPointer) {
+  run_no_throw(R"(
+type inner = record a: longint; end;
+     outer = record i:^inner; end;
+var o: outer;
+begin
+  new(o.i); o.i^.a:=10; dispose(o.i);
+end.)");
+}
+
+TEST(ComplexTests, PointerMath) {
+  run_no_throw(R"(
+var p:^longint;
+begin
+  new(p); p^:=2; p^:=p^*3; dispose(p);
+end.)");
+}
+
+TEST(ComplexTests, RecordArrayDynamic) {
+  run_no_throw(R"(
+type item = record val: unsigned; end;
+     itemArr = ^array[1..10] of item;
+var p: itemArr;
+begin
+  new(p); p^[1].val:=0; dispose(p);
+end.)");
+}
+
+TEST(ComplexTests, PointerToUIntArray) {
+  run_no_throw(R"(
+type uintArr = ^array[1..5] of unsigned;
+var p: uintArr;
+begin
+  new(p); p^[5]:=10; dispose(p);
+end.)");
+}
+
+TEST(ComplexTests, StructWithMatrix) {
+  run_no_throw(R"(
+type mat = record m: array[1..2,1..2] of longint; end;
+var v: mat;
+begin
+  v.m[1,1]:=1;
+end.)");
+}
+
+TEST(ComplexTests, FloatPointer) {
+  run_no_throw(R"(
+var p:^real;
+begin
+  new(p); p^:=3.14; dispose(p);
+end.)");
+}
+
+TEST(ComplexTests, DynamicStringPointer) {
+  run_no_throw(R"(
+type sp = ^string;
+var p: sp;
+begin
+  new(p); p^:='hi'; dispose(p);
+end.)");
+}
+
+TEST(ComplexTests, FibonacciRecursive) {
+  run_no_throw(R"(
+function fib(n: longint): longint;
+begin
+  if n<2 then fib:=n else fib:=fib(n-1)+fib(n-2);
+end;
+begin
+  fib(5);
+end.)");
+}

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Simple test runner for the C++ Pascal compiler
+set -e
+
+TEST_BIN=../build/tests
+
+if [ ! -x "$TEST_BIN" ]; then
+  echo "Tests not built" >&2
+  exit 1
+fi
+
+"$TEST_BIN"
+


### PR DESCRIPTION
## Summary
- reorganize compiler headers and sources into token, scanner, parser and visitors folders
- update Makefile source list for new layout
- adjust includes in main program and tests

## Testing
- `make compiler`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_e_685df45d7d60833098ffbaf2879db92e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Initial Pascal compiler project structure established, supporting C++23.
  * Basic components added: lexer, parser, code generator, and memory manager stubs.
  * Makefile provided for building and testing the compiler.
  * Example main program outputs a stub message.

* **Documentation**
  * Comprehensive documentation added, including project overview, build instructions, language grammar, and contribution guidelines.

* **Tests**
  * Extensive test suites introduced for parser and lexer, covering a wide range of Pascal language constructs.
  * Test runner script included for automated test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->