### PR TITLE
Expand AST definitions

### DIFF
--- a/include/parser/ast.hpp
+++ b/include/parser/ast.hpp
@@ -1,8 +1,10 @@
 #ifndef PASCAL_COMPILER_AST_HPP
 #define PASCAL_COMPILER_AST_HPP
 
+#include "token/types.hpp"
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace pascal {
@@ -28,7 +30,16 @@ enum class NodeKind {
   BinaryExpr,
   UnaryExpr,
   LiteralExpr,
-  VariableExpr
+  VariableExpr,
+  Range,
+  TypeSpec,
+  SimpleTypeSpec,
+  ArrayTypeSpec,
+  RecordTypeSpec,
+  PointerTypeSpec,
+  CaseLabel,
+  NewExpr,
+  DisposeExpr
 };
 
 // Forward declarations for visitor
@@ -53,6 +64,15 @@ struct BinaryExpr;
 struct UnaryExpr;
 struct LiteralExpr;
 struct VariableExpr;
+struct Range;
+struct TypeSpec;
+struct SimpleTypeSpec;
+struct ArrayTypeSpec;
+struct RecordTypeSpec;
+struct PointerTypeSpec;
+struct CaseLabel;
+struct NewExpr;
+struct DisposeExpr;
 
 class NodeVisitor {
 public:
@@ -78,6 +98,15 @@ public:
   virtual void visitUnaryExpr(const UnaryExpr &) = 0;
   virtual void visitLiteralExpr(const LiteralExpr &) = 0;
   virtual void visitVariableExpr(const VariableExpr &) = 0;
+  virtual void visitRange(const Range &) = 0;
+  virtual void visitTypeSpec(const TypeSpec &) = 0;
+  virtual void visitSimpleTypeSpec(const SimpleTypeSpec &) = 0;
+  virtual void visitArrayTypeSpec(const ArrayTypeSpec &) = 0;
+  virtual void visitRecordTypeSpec(const RecordTypeSpec &) = 0;
+  virtual void visitPointerTypeSpec(const PointerTypeSpec &) = 0;
+  virtual void visitCaseLabel(const CaseLabel &) = 0;
+  virtual void visitNewExpr(const NewExpr &) = 0;
+  virtual void visitDisposeExpr(const DisposeExpr &) = 0;
 };
 
 struct ASTNode {
@@ -103,67 +132,134 @@ struct Declaration : ASTNode {
 struct Program : ASTNode {
   std::string name;
   std::unique_ptr<class Block> block;
+
+  Program() : ASTNode(NodeKind::Program) {}
+  Program(std::string n, std::unique_ptr<Block> b)
+      : ASTNode(NodeKind::Program), name(std::move(n)), block(std::move(b)) {}
+
   void accept(NodeVisitor &v) const override { v.visitProgram(*this); }
 };
 
 struct Block : ASTNode {
   std::vector<std::unique_ptr<Declaration>> declarations;
   std::vector<std::unique_ptr<Statement>> statements;
+
+  Block() : ASTNode(NodeKind::Block) {}
+  Block(std::vector<std::unique_ptr<Declaration>> decls,
+        std::vector<std::unique_ptr<Statement>> stmts)
+      : ASTNode(NodeKind::Block), declarations(std::move(decls)),
+        statements(std::move(stmts)) {}
+
   void accept(NodeVisitor &v) const override { v.visitBlock(*this); }
 };
 
 struct VarDecl : Declaration {
-  std::string name;
-  std::string type;
+  std::vector<std::string> names;
+  std::unique_ptr<TypeSpec> type;
+
+  VarDecl() : Declaration(NodeKind::VarDecl) {}
+  VarDecl(std::vector<std::string> n, std::unique_ptr<TypeSpec> t)
+      : Declaration(NodeKind::VarDecl), names(std::move(n)),
+        type(std::move(t)) {}
+
   void accept(NodeVisitor &v) const override { v.visitVarDecl(*this); }
 };
 
 struct ConstDecl : Declaration {
   std::string name;
   std::unique_ptr<Expression> value;
+
+  ConstDecl() : Declaration(NodeKind::ConstDecl) {}
+  ConstDecl(std::string n, std::unique_ptr<Expression> v)
+      : Declaration(NodeKind::ConstDecl), name(std::move(n)),
+        value(std::move(v)) {}
+
   void accept(NodeVisitor &v) const override { v.visitConstDecl(*this); }
 };
 
 struct TypeDecl : Declaration {
   std::string name;
+  std::unique_ptr<TypeSpec> type;
+
+  TypeDecl() : Declaration(NodeKind::TypeDecl) {}
+  TypeDecl(std::string n, std::unique_ptr<TypeSpec> t)
+      : Declaration(NodeKind::TypeDecl), name(std::move(n)),
+        type(std::move(t)) {}
+
   void accept(NodeVisitor &v) const override { v.visitTypeDecl(*this); }
 };
 
 struct ProcedureDecl : Declaration {
   std::string name;
-  std::vector<std::unique_ptr<Declaration>> params;
+  std::vector<std::unique_ptr<ParamDecl>> params;
   std::unique_ptr<Block> body;
+
+  ProcedureDecl() : Declaration(NodeKind::ProcedureDecl) {}
+  ProcedureDecl(std::string n, std::vector<std::unique_ptr<ParamDecl>> p,
+                std::unique_ptr<Block> b)
+      : Declaration(NodeKind::ProcedureDecl), name(std::move(n)),
+        params(std::move(p)), body(std::move(b)) {}
+
   void accept(NodeVisitor &v) const override { v.visitProcedureDecl(*this); }
 };
 
 struct ParamDecl : Declaration {
-  std::string name;
-  std::string type;
+  std::vector<std::string> names;
+  std::unique_ptr<TypeSpec> type;
+
+  ParamDecl() : Declaration(NodeKind::ParamDecl) {}
+  ParamDecl(std::vector<std::string> n, std::unique_ptr<TypeSpec> t)
+      : Declaration(NodeKind::ParamDecl), names(std::move(n)),
+        type(std::move(t)) {}
+
   void accept(NodeVisitor &v) const override { v.visitParamDecl(*this); }
 };
 
 struct FunctionDecl : Declaration {
   std::string name;
-  std::vector<std::unique_ptr<Declaration>> params;
-  std::string returnType;
+  std::vector<std::unique_ptr<ParamDecl>> params;
+  std::unique_ptr<TypeSpec> returnType;
   std::unique_ptr<Block> body;
+
+  FunctionDecl() : Declaration(NodeKind::FunctionDecl) {}
+  FunctionDecl(std::string n, std::vector<std::unique_ptr<ParamDecl>> p,
+               std::unique_ptr<TypeSpec> r, std::unique_ptr<Block> b)
+      : Declaration(NodeKind::FunctionDecl), name(std::move(n)),
+        params(std::move(p)), returnType(std::move(r)), body(std::move(b)) {}
+
   void accept(NodeVisitor &v) const override { v.visitFunctionDecl(*this); }
 };
 
 struct CompoundStmt : Statement {
   std::vector<std::unique_ptr<Statement>> statements;
+
+  CompoundStmt() : Statement(NodeKind::CompoundStmt) {}
+  explicit CompoundStmt(std::vector<std::unique_ptr<Statement>> stmts)
+      : Statement(NodeKind::CompoundStmt), statements(std::move(stmts)) {}
+
   void accept(NodeVisitor &v) const override { v.visitCompoundStmt(*this); }
 };
 
 struct AssignStmt : Statement {
   std::unique_ptr<Expression> target;
   std::unique_ptr<Expression> value;
+
+  AssignStmt() : Statement(NodeKind::AssignStmt) {}
+  AssignStmt(std::unique_ptr<Expression> t, std::unique_ptr<Expression> v)
+      : Statement(NodeKind::AssignStmt), target(std::move(t)),
+        value(std::move(v)) {}
+
   void accept(NodeVisitor &v) const override { v.visitAssignStmt(*this); }
 };
 
 struct ProcCall : Statement {
   std::string name;
   std::vector<std::unique_ptr<Expression>> args;
+
+  ProcCall() : Statement(NodeKind::ProcCall) {}
+  ProcCall(std::string n, std::vector<std::unique_ptr<Expression>> a)
+      : Statement(NodeKind::ProcCall), name(std::move(n)), args(std::move(a)) {}
+
   void accept(NodeVisitor &v) const override { v.visitProcCall(*this); }
 };
 
@@ -171,37 +267,78 @@ struct IfStmt : Statement {
   std::unique_ptr<Expression> condition;
   std::unique_ptr<Statement> thenBranch;
   std::unique_ptr<Statement> elseBranch;
+
+  IfStmt() : Statement(NodeKind::IfStmt) {}
+  IfStmt(std::unique_ptr<Expression> cond, std::unique_ptr<Statement> thenB,
+         std::unique_ptr<Statement> elseB = {})
+      : Statement(NodeKind::IfStmt), condition(std::move(cond)),
+        thenBranch(std::move(thenB)), elseBranch(std::move(elseB)) {}
+
   void accept(NodeVisitor &v) const override { v.visitIfStmt(*this); }
 };
 
 struct WhileStmt : Statement {
   std::unique_ptr<Expression> condition;
   std::unique_ptr<Statement> body;
+
+  WhileStmt() : Statement(NodeKind::WhileStmt) {}
+  WhileStmt(std::unique_ptr<Expression> cond, std::unique_ptr<Statement> b)
+      : Statement(NodeKind::WhileStmt), condition(std::move(cond)),
+        body(std::move(b)) {}
+
   void accept(NodeVisitor &v) const override { v.visitWhileStmt(*this); }
 };
 
 struct ForStmt : Statement {
-  std::unique_ptr<Statement> init;
+  std::unique_ptr<AssignStmt> init;
+  bool downto{false};
   std::unique_ptr<Expression> limit;
   std::unique_ptr<Statement> body;
+
+  ForStmt() : Statement(NodeKind::ForStmt) {}
+  ForStmt(std::unique_ptr<AssignStmt> i, bool d, std::unique_ptr<Expression> l,
+          std::unique_ptr<Statement> b)
+      : Statement(NodeKind::ForStmt), init(std::move(i)), downto(d),
+        limit(std::move(l)), body(std::move(b)) {}
+
   void accept(NodeVisitor &v) const override { v.visitForStmt(*this); }
 };
 
 struct RepeatStmt : Statement {
   std::vector<std::unique_ptr<Statement>> body;
   std::unique_ptr<Expression> condition;
+
+  RepeatStmt() : Statement(NodeKind::RepeatStmt) {}
+  RepeatStmt(std::vector<std::unique_ptr<Statement>> b,
+             std::unique_ptr<Expression> cond)
+      : Statement(NodeKind::RepeatStmt), body(std::move(b)),
+        condition(std::move(cond)) {}
+
   void accept(NodeVisitor &v) const override { v.visitRepeatStmt(*this); }
 };
 
 struct CaseStmt : Statement {
   std::unique_ptr<Expression> expr;
-  std::vector<std::unique_ptr<Statement>> cases;
+  std::vector<std::unique_ptr<CaseLabel>> cases;
+
+  CaseStmt() : Statement(NodeKind::CaseStmt) {}
+  CaseStmt(std::unique_ptr<Expression> e,
+           std::vector<std::unique_ptr<CaseLabel>> c)
+      : Statement(NodeKind::CaseStmt), expr(std::move(e)), cases(std::move(c)) {
+  }
+
   void accept(NodeVisitor &v) const override { v.visitCaseStmt(*this); }
 };
 
 struct WithStmt : Statement {
   std::unique_ptr<Expression> recordExpr;
   std::unique_ptr<Statement> body;
+
+  WithStmt() : Statement(NodeKind::WithStmt) {}
+  WithStmt(std::unique_ptr<Expression> expr, std::unique_ptr<Statement> b)
+      : Statement(NodeKind::WithStmt), recordExpr(std::move(expr)),
+        body(std::move(b)) {}
+
   void accept(NodeVisitor &v) const override { v.visitWithStmt(*this); }
 };
 
@@ -209,23 +346,152 @@ struct BinaryExpr : Expression {
   std::unique_ptr<Expression> left;
   std::unique_ptr<Expression> right;
   std::string op;
+
+  BinaryExpr() : Expression(NodeKind::BinaryExpr) {}
+  BinaryExpr(std::unique_ptr<Expression> l, std::string o,
+             std::unique_ptr<Expression> r)
+      : Expression(NodeKind::BinaryExpr), left(std::move(l)),
+        right(std::move(r)), op(std::move(o)) {}
+
   void accept(NodeVisitor &v) const override { v.visitBinaryExpr(*this); }
 };
 
 struct UnaryExpr : Expression {
   std::unique_ptr<Expression> operand;
   std::string op;
+
+  UnaryExpr() : Expression(NodeKind::UnaryExpr) {}
+  UnaryExpr(std::string o, std::unique_ptr<Expression> oper)
+      : Expression(NodeKind::UnaryExpr), operand(std::move(oper)),
+        op(std::move(o)) {}
+
   void accept(NodeVisitor &v) const override { v.visitUnaryExpr(*this); }
 };
 
 struct LiteralExpr : Expression {
   std::string value;
+
+  LiteralExpr() : Expression(NodeKind::LiteralExpr) {}
+  explicit LiteralExpr(std::string val)
+      : Expression(NodeKind::LiteralExpr), value(std::move(val)) {}
+
   void accept(NodeVisitor &v) const override { v.visitLiteralExpr(*this); }
 };
 
 struct VariableExpr : Expression {
   std::string name;
+  struct Selector {
+    enum class Kind { Field, Index, Pointer };
+    Kind kind{Kind::Field};
+    std::string field;
+    std::unique_ptr<Expression> index;
+
+    Selector() = default;
+    Selector(std::string f, Kind k)
+        : kind(k), field(std::move(f)), index(nullptr) {}
+    Selector(std::unique_ptr<Expression> idx)
+        : kind(Kind::Index), index(std::move(idx)) {}
+  };
+  std::vector<Selector> selectors;
+
+  VariableExpr() : Expression(NodeKind::VariableExpr) {}
+  explicit VariableExpr(std::string n)
+      : Expression(NodeKind::VariableExpr), name(std::move(n)) {}
+  VariableExpr(std::string n, std::vector<Selector> sels)
+      : Expression(NodeKind::VariableExpr), name(std::move(n)),
+        selectors(std::move(sels)) {}
+
   void accept(NodeVisitor &v) const override { v.visitVariableExpr(*this); }
+};
+
+struct Range : ASTNode {
+  int start{0};
+  int end{0};
+
+  Range() : ASTNode(NodeKind::Range) {}
+  Range(int s, int e) : ASTNode(NodeKind::Range), start(s), end(e) {}
+
+  void accept(NodeVisitor &v) const override { v.visitRange(*this); }
+};
+
+struct TypeSpec : ASTNode {
+  using ASTNode::ASTNode;
+};
+
+struct SimpleTypeSpec : TypeSpec {
+  BasicType basic{BasicType::Integer};
+  std::string name;
+
+  SimpleTypeSpec() : TypeSpec(NodeKind::SimpleTypeSpec) {}
+  SimpleTypeSpec(BasicType b, std::string n = {})
+      : TypeSpec(NodeKind::SimpleTypeSpec), basic(b), name(std::move(n)) {}
+
+  void accept(NodeVisitor &v) const override { v.visitSimpleTypeSpec(*this); }
+};
+
+struct ArrayTypeSpec : TypeSpec {
+  std::vector<Range> ranges;
+  std::unique_ptr<TypeSpec> elementType;
+
+  ArrayTypeSpec() : TypeSpec(NodeKind::ArrayTypeSpec) {}
+  ArrayTypeSpec(std::vector<Range> r, std::unique_ptr<TypeSpec> elem)
+      : TypeSpec(NodeKind::ArrayTypeSpec), ranges(std::move(r)),
+        elementType(std::move(elem)) {}
+
+  void accept(NodeVisitor &v) const override { v.visitArrayTypeSpec(*this); }
+};
+
+struct RecordTypeSpec : TypeSpec {
+  std::vector<std::unique_ptr<VarDecl>> fields;
+
+  RecordTypeSpec() : TypeSpec(NodeKind::RecordTypeSpec) {}
+  explicit RecordTypeSpec(std::vector<std::unique_ptr<VarDecl>> f)
+      : TypeSpec(NodeKind::RecordTypeSpec), fields(std::move(f)) {}
+
+  void accept(NodeVisitor &v) const override { v.visitRecordTypeSpec(*this); }
+};
+
+struct PointerTypeSpec : TypeSpec {
+  std::unique_ptr<TypeSpec> refType;
+
+  PointerTypeSpec() : TypeSpec(NodeKind::PointerTypeSpec) {}
+  explicit PointerTypeSpec(std::unique_ptr<TypeSpec> r)
+      : TypeSpec(NodeKind::PointerTypeSpec), refType(std::move(r)) {}
+
+  void accept(NodeVisitor &v) const override { v.visitPointerTypeSpec(*this); }
+};
+
+struct CaseLabel : ASTNode {
+  std::vector<std::unique_ptr<Expression>> constants;
+  std::unique_ptr<Statement> stmt;
+
+  CaseLabel() : ASTNode(NodeKind::CaseLabel) {}
+  CaseLabel(std::vector<std::unique_ptr<Expression>> c,
+            std::unique_ptr<Statement> s)
+      : ASTNode(NodeKind::CaseLabel), constants(std::move(c)),
+        stmt(std::move(s)) {}
+
+  void accept(NodeVisitor &v) const override { v.visitCaseLabel(*this); }
+};
+
+struct NewExpr : Expression {
+  std::unique_ptr<VariableExpr> variable;
+
+  NewExpr() : Expression(NodeKind::NewExpr) {}
+  explicit NewExpr(std::unique_ptr<VariableExpr> var)
+      : Expression(NodeKind::NewExpr), variable(std::move(var)) {}
+
+  void accept(NodeVisitor &v) const override { v.visitNewExpr(*this); }
+};
+
+struct DisposeExpr : Expression {
+  std::unique_ptr<VariableExpr> variable;
+
+  DisposeExpr() : Expression(NodeKind::DisposeExpr) {}
+  explicit DisposeExpr(std::unique_ptr<VariableExpr> var)
+      : Expression(NodeKind::DisposeExpr), variable(std::move(var)) {}
+
+  void accept(NodeVisitor &v) const override { v.visitDisposeExpr(*this); }
 };
 
 struct AST {

--- a/include/parser/parser.hpp
+++ b/include/parser/parser.hpp
@@ -20,12 +20,13 @@ private:
   bool match(TokenType type);
   bool isAtEnd() const;
 
-  std::unique_ptr<ASTNode> parseBlock();
-  std::unique_ptr<ASTNode> parseDeclaration();
-  std::unique_ptr<ASTNode> parseStatement();
-  std::unique_ptr<ASTNode> parseExpression();
+  std::unique_ptr<Block> parseBlock();
+  std::unique_ptr<Declaration> parseDeclaration();
+  std::unique_ptr<Statement> parseStatement();
+  std::unique_ptr<Expression> parseExpression();
+  std::unique_ptr<TypeSpec> parseTypeSpec();
 
-  AST parseProgram();
+  std::unique_ptr<Program> parseProgram();
 
   const std::vector<Token> &m_tokens;
   std::size_t m_current{0};

--- a/include/parser/validator.hpp
+++ b/include/parser/validator.hpp
@@ -30,6 +30,15 @@ public:
   void visitUnaryExpr(const UnaryExpr & /*node*/) override {}
   void visitLiteralExpr(const LiteralExpr & /*node*/) override {}
   void visitVariableExpr(const VariableExpr & /*node*/) override {}
+  void visitRange(const Range & /*node*/) override {}
+  void visitTypeSpec(const TypeSpec & /*node*/) override {}
+  void visitSimpleTypeSpec(const SimpleTypeSpec & /*node*/) override {}
+  void visitArrayTypeSpec(const ArrayTypeSpec & /*node*/) override {}
+  void visitRecordTypeSpec(const RecordTypeSpec & /*node*/) override {}
+  void visitPointerTypeSpec(const PointerTypeSpec & /*node*/) override {}
+  void visitCaseLabel(const CaseLabel & /*node*/) override {}
+  void visitNewExpr(const NewExpr & /*node*/) override {}
+  void visitDisposeExpr(const DisposeExpr & /*node*/) override {}
 
 private:
   bool m_valid{true};

--- a/include/token/token.hpp
+++ b/include/token/token.hpp
@@ -19,6 +19,7 @@ enum class TokenType {
   RightParen,
   LeftBracket,
   RightBracket,
+  Caret,
 
   // One or two character tokens
   Assign,

--- a/include/visitors/codegen.hpp
+++ b/include/visitors/codegen.hpp
@@ -34,6 +34,15 @@ public:
   void visitUnaryExpr(const UnaryExpr & /*node*/) override {}
   void visitLiteralExpr(const LiteralExpr & /*node*/) override {}
   void visitVariableExpr(const VariableExpr & /*node*/) override {}
+  void visitRange(const Range & /*node*/) override {}
+  void visitTypeSpec(const TypeSpec & /*node*/) override {}
+  void visitSimpleTypeSpec(const SimpleTypeSpec & /*node*/) override {}
+  void visitArrayTypeSpec(const ArrayTypeSpec & /*node*/) override {}
+  void visitRecordTypeSpec(const RecordTypeSpec & /*node*/) override {}
+  void visitPointerTypeSpec(const PointerTypeSpec & /*node*/) override {}
+  void visitCaseLabel(const CaseLabel & /*node*/) override {}
+  void visitNewExpr(const NewExpr & /*node*/) override {}
+  void visitDisposeExpr(const DisposeExpr & /*node*/) override {}
 
 private:
   void emit(const std::string &text);

--- a/tests/compiler_tests.cpp
+++ b/tests/compiler_tests.cpp
@@ -4,258 +4,945 @@
 using pascal::AST;
 using pascal::Lexer;
 using pascal::Parser;
-using test_utils::make_expected;
+using pascal::Token;
+using test_utils::make_empty_ast;
 using test_utils::run_full;
+using test_utils::tokens;
+using TT = pascal::TokenType;
 
 // Variable declarations
 TEST(VarDeclTests, Decl1) {
-  run_full("var a: integer;", make_expected({"var", "a", ":", "integer", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "integer"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var a: integer;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
+
 TEST(VarDeclTests, Decl2) {
-  run_full("var b: real;", make_expected({"var", "b", ":", "real", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "b"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "real"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var b: real;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
+
 TEST(VarDeclTests, Decl3) {
-  run_full("var c: unsigned;",
-           make_expected({"var", "c", ":", "unsigned", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "c"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "unsigned"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var c: unsigned;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 
 // Expressions
 TEST(ExpressionTests, Expr1) {
-  run_full("begin a := 1; end.",
-           make_expected({"begin", "a", ":", "=", "1", ";", "end", "."}));
+  std::vector<Token> expected_tokens = tokens({{TT::Begin, "begin"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Dot, "."}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("begin a := 1; end.", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
+
 TEST(ExpressionTests, Expr2) {
-  run_full(
-      "begin b := a + 1; end.",
-      make_expected({"begin", "b", ":", "=", "a", "+", "1", ";", "end", "."}));
+  std::vector<Token> expected_tokens = tokens({{TT::Begin, "begin"},
+                                               {TT::Identifier, "b"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "a"},
+                                               {TT::Plus, "+"},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Dot, "."}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("begin b := a + 1; end.", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
+
 TEST(ExpressionTests, Expr3) {
-  run_full(
-      "begin c := b * 2; end.",
-      make_expected({"begin", "c", ":", "=", "b", "*", "2", ";", "end", "."}));
+  std::vector<Token> expected_tokens = tokens({{TT::Begin, "begin"},
+                                               {TT::Identifier, "c"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "b"},
+                                               {TT::Star, "*"},
+                                               {TT::Number, "2"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Dot, "."}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("begin c := b * 2; end.", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 
 // Control statements
 TEST(ControlTests, IfStmt) {
-  run_full("if a > 0 then b := 1;", make_expected({"if", "a", ">", "0", "then",
-                                                   "b", ":", "=", "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::If, "if"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Greater, ">"},
+                                               {TT::Number, "0"},
+                                               {TT::Then, "then"},
+                                               {TT::Identifier, "b"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("if a > 0 then b := 1;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(ControlTests, IfElse) {
-  run_full("if a > 0 then b := 1 else b := 2;",
-           make_expected({"if", "a", ">", "0", "then", "b", ":", "=", "1",
-                          "else", "b", ":", "=", "2", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::If, "if"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Greater, ">"},
+                                               {TT::Number, "0"},
+                                               {TT::Then, "then"},
+                                               {TT::Identifier, "b"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Else, "else"},
+                                               {TT::Identifier, "b"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "2"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("if a > 0 then b := 1 else b := 2;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(ControlTests, CaseStmt) {
-  run_full("case a of 1: b := 1; end;",
-           make_expected({"case", "a", "of", "1", ":", "b", ":", "=", "1", ";",
-                          "end", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Case, "case"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Of, "of"},
+                                               {TT::Number, "1"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "b"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("case a of 1: b := 1; end;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(ControlTests, WhileStmt) {
-  run_full("while a > 0 do a := a - 1;",
-           make_expected({"while", "a", ">", "0", "do", "a", ":", "=", "a", "-",
-                          "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::While, "while"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Greater, ">"},
+                                               {TT::Number, "0"},
+                                               {TT::Do, "do"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "a"},
+                                               {TT::Minus, "-"},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("while a > 0 do a := a - 1;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(ControlTests, ForStmt) {
-  run_full("for i:=1 to 10 do a:=i;",
-           make_expected({"for", "i", ":", "=", "1", "to", "10", "do", "a", ":",
-                          "=", "i", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::For, "for"},
+                                               {TT::Identifier, "i"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::To, "to"},
+                                               {TT::Number, "10"},
+                                               {TT::Do, "do"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "i"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("for i:=1 to 10 do a:=i;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(ControlTests, RepeatStmt) {
-  run_full("repeat a:=a-1 until a=0;",
-           make_expected({"repeat", "a", ":", "=", "a", "-", "1", "until", "a",
-                          "=", "0", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Repeat, "repeat"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "a"},
+                                               {TT::Minus, "-"},
+                                               {TT::Number, "1"},
+                                               {TT::Until, "until"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Equal, "="},
+                                               {TT::Number, "0"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("repeat a:=a-1 until a=0;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 
 // Functions
 TEST(FunctionTests, Func1) {
-  run_full("function f: integer; begin f:=0; end;",
-           make_expected({"function", "f", ":", "integer", ";", "begin", "f",
-                          ":", "=", "0", ";", "end", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Function, "function"},
+                                               {TT::Identifier, "f"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "integer"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::Begin, "begin"},
+                                               {TT::Identifier, "f"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "0"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("function f: integer; begin f:=0; end;", expected_tokens,
+           expected_ast, expected_asm, expected_output);
 }
 TEST(FunctionTests, Func2) {
-  run_full("procedure p; begin end;",
-           make_expected({"procedure", "p", ";", "begin", "end", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Procedure, "procedure"},
+                                               {TT::Identifier, "p"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::Begin, "begin"},
+                                               {TT::End, "end"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("procedure p; begin end;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(FunctionTests, Func3) {
-  run_full("function g(x: integer): integer; begin g:=x; end;",
-           make_expected({"function", "g", "(", "x", ":", "integer", ")", ":",
-                          "integer", ";", "begin", "g", ":", "=", "x", ";",
-                          "end", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Function, "function"},
+                                               {TT::Identifier, "g"},
+                                               {TT::LeftParen, "("},
+                                               {TT::Identifier, "x"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "integer"},
+                                               {TT::RightParen, ")"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "integer"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::Begin, "begin"},
+                                               {TT::Identifier, "g"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "x"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("function g(x: integer): integer; begin g:=x; end;", expected_tokens,
+           expected_ast, expected_asm, expected_output);
 }
 
 // Float
 TEST(FloatTests, Float1) {
-  run_full("var x: real; x:=1.0;",
-           make_expected({"var", "x", ":", "real", ";", "x", ":", "=", "1", ".",
-                          "0", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "x"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "real"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::Identifier, "x"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "0"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var x: real; x:=1.0;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(FloatTests, Float2) {
-  run_full("x:=1.5+2.5;", make_expected({"x", ":", "=", "1", ".", "5", "+", "2",
-                                         ".", "5", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "x"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "5"},
+                                               {TT::Plus, "+"},
+                                               {TT::Number, "2"},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "5"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("x:=1.5+2.5;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(FloatTests, Float3) {
-  run_full("if 0.0 < 1.0 then x:=0.0;",
-           make_expected({"if", "0", ".", "0", "<", "1", ".", "0", "then", "x",
-                          ":", "=", "0", ".", "0", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::If, "if"},
+                                               {TT::Number, "0"},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "0"},
+                                               {TT::Less, "<"},
+                                               {TT::Number, "1"},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "0"},
+                                               {TT::Then, "then"},
+                                               {TT::Identifier, "x"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "0"},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "0"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("if 0.0 < 1.0 then x:=0.0;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(FloatTests, Float4) {
-  run_full("while x < 1.0 do x:=x+0.1;",
-           make_expected({"while", "x", "<", "1", ".", "0", "do", "x", ":", "=",
-                          "x", "+", "0", ".", "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::While, "while"},
+                                               {TT::Identifier, "x"},
+                                               {TT::Less, "<"},
+                                               {TT::Number, "1"},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "0"},
+                                               {TT::Do, "do"},
+                                               {TT::Identifier, "x"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "x"},
+                                               {TT::Plus, "+"},
+                                               {TT::Number, "0"},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("while x < 1.0 do x:=x+0.1;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(FloatTests, Float5) {
-  run_full("function f: real; begin f:=0.0; end;",
-           make_expected({"function", "f", ":", "real", ";", "begin", "f", ":",
-                          "=", "0", ".", "0", ";", "end", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Function, "function"},
+                                               {TT::Identifier, "f"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "real"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::Begin, "begin"},
+                                               {TT::Identifier, "f"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "0"},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "0"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("function f: real; begin f:=0.0; end;", expected_tokens,
+           expected_ast, expected_asm, expected_output);
 }
 
 // Unsigned int
 TEST(UnsignedTests, Uns1) {
-  run_full("var u: unsigned;",
-           make_expected({"var", "u", ":", "unsigned", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "u"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "unsigned"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var u: unsigned;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(UnsignedTests, Uns2) {
-  run_full("u:=1;", make_expected({"u", ":", "=", "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "u"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("u:=1;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(UnsignedTests, Uns3) {
-  run_full("while u>0 do u:=u-1;",
-           make_expected({"while", "u", ">", "0", "do", "u", ":", "=", "u", "-",
-                          "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::While, "while"},
+                                               {TT::Identifier, "u"},
+                                               {TT::Greater, ">"},
+                                               {TT::Number, "0"},
+                                               {TT::Do, "do"},
+                                               {TT::Identifier, "u"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "u"},
+                                               {TT::Minus, "-"},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("while u>0 do u:=u-1;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(UnsignedTests, Uns4) {
-  run_full("function f: unsigned; begin f:=0; end;",
-           make_expected({"function", "f", ":", "unsigned", ";", "begin", "f",
-                          ":", "=", "0", ";", "end", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Function, "function"},
+                                               {TT::Identifier, "f"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "unsigned"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::Begin, "begin"},
+                                               {TT::Identifier, "f"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "0"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("function f: unsigned; begin f:=0; end;", expected_tokens,
+           expected_ast, expected_asm, expected_output);
 }
 TEST(UnsignedTests, Uns5) {
-  run_full("for u:=1 to 5 do u:=u;",
-           make_expected({"for", "u", ":", "=", "1", "to", "5", "do", "u", ":",
-                          "=", "u", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::For, "for"},
+                                               {TT::Identifier, "u"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::To, "to"},
+                                               {TT::Number, "5"},
+                                               {TT::Do, "do"},
+                                               {TT::Identifier, "u"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "u"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("for u:=1 to 5 do u:=u;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 
 // Long int
 TEST(LongIntTests, Long1) {
-  run_full("var l: longint;", make_expected({"var", "l", ":", "longint", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "l"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "longint"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var l: longint;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(LongIntTests, Long2) {
-  run_full("l:=1;", make_expected({"l", ":", "=", "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "l"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("l:=1;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(LongIntTests, Long3) {
-  run_full("while l>0 do l:=l-1;",
-           make_expected({"while", "l", ">", "0", "do", "l", ":", "=", "l", "-",
-                          "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::While, "while"},
+                                               {TT::Identifier, "l"},
+                                               {TT::Greater, ">"},
+                                               {TT::Number, "0"},
+                                               {TT::Do, "do"},
+                                               {TT::Identifier, "l"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "l"},
+                                               {TT::Minus, "-"},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("while l>0 do l:=l-1;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(LongIntTests, Long4) {
-  run_full("function f: longint; begin f:=0; end;",
-           make_expected({"function", "f", ":", "longint", ";", "begin", "f",
-                          ":", "=", "0", ";", "end", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Function, "function"},
+                                               {TT::Identifier, "f"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "longint"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::Begin, "begin"},
+                                               {TT::Identifier, "f"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "0"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("function f: longint; begin f:=0; end;", expected_tokens,
+           expected_ast, expected_asm, expected_output);
 }
 TEST(LongIntTests, Long5) {
-  run_full("for l:=1 to 5 do l:=l;",
-           make_expected({"for", "l", ":", "=", "1", "to", "5", "do", "l", ":",
-                          "=", "l", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::For, "for"},
+                                               {TT::Identifier, "l"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::To, "to"},
+                                               {TT::Number, "5"},
+                                               {TT::Do, "do"},
+                                               {TT::Identifier, "l"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "l"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("for l:=1 to 5 do l:=l;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 
 // Dynamic memory
 TEST(DynamicTests, Dyn1) {
-  run_full("new(p);", make_expected({"new", "(", "p", ")", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::New, "new"},
+                                               {TT::LeftParen, "("},
+                                               {TT::Identifier, "p"},
+                                               {TT::RightParen, ")"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("new(p);", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(DynamicTests, Dyn2) {
-  run_full("dispose(p);", make_expected({"dispose", "(", "p", ")", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Dispose, "dispose"},
+                                               {TT::LeftParen, "("},
+                                               {TT::Identifier, "p"},
+                                               {TT::RightParen, ")"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("dispose(p);", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(DynamicTests, Dyn3) {
-  run_full("var p:^integer;",
-           make_expected({"var", "p", ":", "^", "integer", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "p"},
+                                               {TT::Colon, ":"},
+                                               {TT::Caret, "^"},
+                                               {TT::Identifier, "integer"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var p:^integer;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(DynamicTests, Dyn4) {
-  run_full("p^:=1;", make_expected({"p", "^", ":", "=", "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "p"},
+                                               {TT::Caret, "^"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("p^:=1;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(DynamicTests, Dyn5) {
-  run_full("if p<>nil then dispose(p);",
-           make_expected({"if", "p", "<", ">", "nil", "then", "dispose", "(",
-                          "p", ")", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::If, "if"},
+                                               {TT::Identifier, "p"},
+                                               {TT::Less, "<"},
+                                               {TT::Greater, ">"},
+                                               {TT::Identifier, "nil"},
+                                               {TT::Then, "then"},
+                                               {TT::Dispose, "dispose"},
+                                               {TT::LeftParen, "("},
+                                               {TT::Identifier, "p"},
+                                               {TT::RightParen, ")"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("if p<>nil then dispose(p);", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 
 // Strings
 TEST(StringTests, Str1) {
-  run_full("var s: string;", make_expected({"var", "s", ":", "string", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "s"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "string"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var s: string;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(StringTests, Str2) {
-  run_full("s:='hi';", make_expected({"s", ":", "=", "'", "hi", "'", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "s"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "'"},
+                                               {TT::Identifier, "hi"},
+                                               {TT::Identifier, "'"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("s:='hi';", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(StringTests, Str3) {
-  run_full("s:=s+'!';",
-           make_expected({"s", ":", "=", "s", "+", "'", "!", "'", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "s"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "s"},
+                                               {TT::Plus, "+"},
+                                               {TT::Identifier, "'"},
+                                               {TT::Identifier, "!"},
+                                               {TT::Identifier, "'"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("s:=s+'!';", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(StringTests, Str4) {
-  run_full("writeln(s);", make_expected({"writeln", "(", "s", ")", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "writeln"},
+                                               {TT::LeftParen, "("},
+                                               {TT::Identifier, "s"},
+                                               {TT::RightParen, ")"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("writeln(s);", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(StringTests, Str5) {
-  run_full("if s='' then s:='a';",
-           make_expected({"if", "s", "=", "'", "'", "then", "s", ":", "=", "'",
-                          "a", "'", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::If, "if"},
+                                               {TT::Identifier, "s"},
+                                               {TT::Equal, "="},
+                                               {TT::Identifier, "'"},
+                                               {TT::Identifier, "'"},
+                                               {TT::Then, "then"},
+                                               {TT::Identifier, "s"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "'"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Identifier, "'"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("if s='' then s:='a';", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 
 // Arrays
 TEST(ArrayTests, Arr1) {
-  run_full("var a: array[1..5] of integer;",
-           make_expected({"var", "a", ":", "array", "[", "1", ".", ".", "5",
-                          "]", "of", "integer", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Array, "array"},
+                                               {TT::LeftBracket, "["},
+                                               {TT::Number, "1"},
+                                               {TT::Dot, "."},
+                                               {TT::Dot, "."},
+                                               {TT::Number, "5"},
+                                               {TT::RightBracket, "]"},
+                                               {TT::Of, "of"},
+                                               {TT::Identifier, "integer"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var a: array[1..5] of integer;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(ArrayTests, Arr2) {
-  run_full("a[1]:=0;", make_expected({"a", "[", "1", "]", ":", "=", "0", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "a"},
+                                               {TT::LeftBracket, "["},
+                                               {TT::Number, "1"},
+                                               {TT::RightBracket, "]"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "0"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("a[1]:=0;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(ArrayTests, Arr3) {
-  run_full("for i:=1 to 5 do a[i]:=i;",
-           make_expected({"for", "i", ":", "=", "1", "to", "5", "do", "a", "[",
-                          "i", "]", ":", "=", "i", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::For, "for"},
+                                               {TT::Identifier, "i"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::To, "to"},
+                                               {TT::Number, "5"},
+                                               {TT::Do, "do"},
+                                               {TT::Identifier, "a"},
+                                               {TT::LeftBracket, "["},
+                                               {TT::Identifier, "i"},
+                                               {TT::RightBracket, "]"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "i"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("for i:=1 to 5 do a[i]:=i;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(ArrayTests, Arr4) {
-  run_full("writeln(a[1]);",
-           make_expected({"writeln", "(", "a", "[", "1", "]", ")", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "writeln"},
+                                               {TT::LeftParen, "("},
+                                               {TT::Identifier, "a"},
+                                               {TT::LeftBracket, "["},
+                                               {TT::Number, "1"},
+                                               {TT::RightBracket, "]"},
+                                               {TT::RightParen, ")"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("writeln(a[1]);", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(ArrayTests, Arr5) {
-  run_full("if a[1]=0 then a[1]:=1;",
-           make_expected({"if", "a", "[", "1", "]", "=", "0", "then", "a", "[",
-                          "1", "]", ":", "=", "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::If, "if"},
+                                               {TT::Identifier, "a"},
+                                               {TT::LeftBracket, "["},
+                                               {TT::Number, "1"},
+                                               {TT::RightBracket, "]"},
+                                               {TT::Equal, "="},
+                                               {TT::Number, "0"},
+                                               {TT::Then, "then"},
+                                               {TT::Identifier, "a"},
+                                               {TT::LeftBracket, "["},
+                                               {TT::Number, "1"},
+                                               {TT::RightBracket, "]"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("if a[1]=0 then a[1]:=1;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 
 // Struct (record)
 TEST(StructTests, Rec1) {
-  run_full("type r=record a:integer; end;",
-           make_expected({"type", "r", "=", "record", "a", ":", "integer", ";",
-                          "end", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"},
+                                               {TT::Identifier, "r"},
+                                               {TT::Equal, "="},
+                                               {TT::Record, "record"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "integer"},
+                                               {TT::Semicolon, ";"},
+                                               {TT::End, "end"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("type r=record a:integer; end;", expected_tokens, expected_ast,
+           expected_asm, expected_output);
 }
 TEST(StructTests, Rec2) {
-  run_full("var v:r;", make_expected({"var", "v", ":", "r", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "v"},
+                                               {TT::Colon, ":"},
+                                               {TT::Identifier, "r"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var v:r;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(StructTests, Rec3) {
-  run_full("v.a:=1;", make_expected({"v", ".", "a", ":", "=", "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "v"},
+                                               {TT::Dot, "."},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("v.a:=1;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(StructTests, Rec4) {
-  run_full("with v do a:=2;",
-           make_expected({"with", "v", "do", "a", ":", "=", "2", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::With, "with"},
+                                               {TT::Identifier, "v"},
+                                               {TT::Do, "do"},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "2"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("with v do a:=2;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(StructTests, Rec5) {
-  run_full("if v.a=0 then v.a:=1;",
-           make_expected({"if", "v", ".", "a", "=", "0", "then", "v", ".", "a",
-                          ":", "=", "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::If, "if"},
+                                               {TT::Identifier, "v"},
+                                               {TT::Dot, "."},
+                                               {TT::Identifier, "a"},
+                                               {TT::Equal, "="},
+                                               {TT::Number, "0"},
+                                               {TT::Then, "then"},
+                                               {TT::Identifier, "v"},
+                                               {TT::Dot, "."},
+                                               {TT::Identifier, "a"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("if v.a=0 then v.a:=1;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 
 // Pointers
 TEST(PointerTests, Ptr1) {
-  run_full("var p:^integer;",
-           make_expected({"var", "p", ":", "^", "integer", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"},
+                                               {TT::Identifier, "p"},
+                                               {TT::Colon, ":"},
+                                               {TT::Caret, "^"},
+                                               {TT::Identifier, "integer"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("var p:^integer;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(PointerTests, Ptr2) {
-  run_full("new(p);", make_expected({"new", "(", "p", ")", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::New, "new"},
+                                               {TT::LeftParen, "("},
+                                               {TT::Identifier, "p"},
+                                               {TT::RightParen, ")"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("new(p);", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(PointerTests, Ptr3) {
-  run_full("p^:=1;", make_expected({"p", "^", ":", "=", "1", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "p"},
+                                               {TT::Caret, "^"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Number, "1"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("p^:=1;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(PointerTests, Ptr4) {
-  run_full("dispose(p);", make_expected({"dispose", "(", "p", ")", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Dispose, "dispose"},
+                                               {TT::LeftParen, "("},
+                                               {TT::Identifier, "p"},
+                                               {TT::RightParen, ")"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("dispose(p);", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }
 TEST(PointerTests, Ptr5) {
-  run_full("p:=nil;", make_expected({"p", ":", "=", "nil", ";"}));
+  std::vector<Token> expected_tokens = tokens({{TT::Identifier, "p"},
+                                               {TT::Colon, ":"},
+                                               {TT::Assign, "="},
+                                               {TT::Identifier, "nil"},
+                                               {TT::Semicolon, ";"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
+  run_full("p:=nil;", expected_tokens, expected_ast, expected_asm,
+           expected_output);
 }

--- a/tests/complex_tests.cpp
+++ b/tests/complex_tests.cpp
@@ -4,10 +4,17 @@
 using pascal::AST;
 using pascal::Lexer;
 using pascal::Parser;
-using test_utils::default_expected;
+using pascal::Token;
+using test_utils::make_empty_ast;
 using test_utils::run_full;
+using test_utils::tokens;
+using TT = pascal::TokenType;
 
 TEST(ComplexTests, FibonacciArray) {
+  std::vector<Token> expected_tokens = tokens({{TT::Program, "program"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 program Fib;
 var i: longint; f: array[1..10] of longint;
@@ -16,17 +23,14 @@ begin
   for i:=3 to 10 do
     f[i]:=f[i-1]+f[i-2];
 end.)",
-           default_expected(R"(
-program Fib;
-var i: longint; f: array[1..10] of longint;
-begin
-  f[1]:=1; f[2]:=1;
-  for i:=3 to 10 do
-    f[i]:=f[i-1]+f[i-2];
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, FactorialUnsigned) {
+  std::vector<Token> expected_tokens = tokens({{TT::Function, "function"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 function fact(n: unsigned): unsigned;
 begin
@@ -36,18 +40,14 @@ end;
 begin
   fact(5);
 end.)",
-           default_expected(R"(
-function fact(n: unsigned): unsigned;
-begin
-  if n=0 then fact:=1
-  else fact:=n*fact(n-1);
-end;
-begin
-  fact(5);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, RecordPointer) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type pr = ^rec;
      rec = record val: longint; next: pr; end;
@@ -55,76 +55,70 @@ var p: pr;
 begin
   new(p); p^.val:=1; dispose(p);
 end.)",
-           default_expected(R"(
-type pr = ^rec;
-     rec = record val: longint; next: pr; end;
-var p: pr;
-begin
-  new(p); p^.val:=1; dispose(p);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, StringConcat) {
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 var s: string;
 begin
   s:='Hello';
   s:=s+' World';
 end.)",
-           default_expected(R"(
-var s: string;
-begin
-  s:='Hello';
-  s:=s+' World';
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, FloatArray) {
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 var a: array[1..3] of real; i: integer;
 begin
   a[1]:=1.1; a[2]:=2.2; a[3]:=3.3;
   for i:=1 to 3 do a[i]:=a[i]*2.0;
 end.)",
-           default_expected(R"(
-var a: array[1..3] of real; i: integer;
-begin
-  a[1]:=1.1; a[2]:=2.2; a[3]:=3.3;
-  for i:=1 to 3 do a[i]:=a[i]*2.0;
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, PointerRecord) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type r = record x: integer; end;
 var p:^r;
 begin
   new(p); p^.x:=5; dispose(p);
 end.)",
-           default_expected(R"(
-type r = record x: integer; end;
-var p:^r;
-begin
-  new(p); p^.x:=5; dispose(p);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, MatrixLongint) {
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 var m: array[1..2,1..2] of longint;
 begin
   m[1,1]:=1; m[1,2]:=2;
   m[2,1]:=3; m[2,2]:=4;
 end.)",
-           default_expected(R"(
-var m: array[1..2,1..2] of longint;
-begin
-  m[1,1]:=1; m[1,2]:=2;
-  m[2,1]:=3; m[2,2]:=4;
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, LinkedList) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type nodep = ^node;
      node = record val: longint; next: nodep; end;
@@ -133,32 +127,28 @@ begin
   new(head); new(node1);
   head^.next:=node1; node1^.next:=nil;
 end.)",
-           default_expected(R"(
-type nodep = ^node;
-     node = record val: longint; next: nodep; end;
-var head,node1: nodep;
-begin
-  new(head); new(node1);
-  head^.next:=node1; node1^.next:=nil;
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, DynamicFloatArray) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type arrp = ^array[1..5] of real;
 var p: arrp;
 begin
   new(p); p^[1]:=1.0; dispose(p);
 end.)",
-           default_expected(R"(
-type arrp = ^array[1..5] of real;
-var p: arrp;
-begin
-  new(p); p^[1]:=1.0; dispose(p);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, SortLongint) {
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 var a: array[1..3] of longint; i,j,t: longint;
 begin
@@ -167,47 +157,42 @@ begin
       if a[i]>a[j] then
         begin t:=a[i]; a[i]:=a[j]; a[j]:=t; end;
 end.)",
-           default_expected(R"(
-var a: array[1..3] of longint; i,j,t: longint;
-begin
-  for i:=1 to 2 do
-    for j:=i+1 to 3 do
-      if a[i]>a[j] then
-        begin t:=a[i]; a[i]:=a[j]; a[j]:=t; end;
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, ArrayOfStrings) {
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 var names: array[1..2] of string;
 begin
   names[1]:='Alice';
   names[2]:='Bob';
 end.)",
-           default_expected(R"(
-var names: array[1..2] of string;
-begin
-  names[1]:='Alice';
-  names[2]:='Bob';
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, PointerRecordString) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type person = record name: string; end;
 var p:^person;
 begin
   new(p); p^.name:='Ana'; dispose(p);
 end.)",
-           default_expected(R"(
-type person = record name: string; end;
-var p:^person;
-begin
-  new(p); p^.name:='Ana'; dispose(p);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, NestedRecordPointer) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type inner = record a: longint; end;
      outer = record i:^inner; end;
@@ -215,29 +200,27 @@ var o: outer;
 begin
   new(o.i); o.i^.a:=10; dispose(o.i);
 end.)",
-           default_expected(R"(
-type inner = record a: longint; end;
-     outer = record i:^inner; end;
-var o: outer;
-begin
-  new(o.i); o.i^.a:=10; dispose(o.i);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, PointerMath) {
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 var p:^longint;
 begin
   new(p); p^:=2; p^:=p^*3; dispose(p);
 end.)",
-           default_expected(R"(
-var p:^longint;
-begin
-  new(p); p^:=2; p^:=p^*3; dispose(p);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, RecordArrayDynamic) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type item = record val: unsigned; end;
      itemArr = ^array[1..10] of item;
@@ -245,74 +228,69 @@ var p: itemArr;
 begin
   new(p); p^[1].val:=0; dispose(p);
 end.)",
-           default_expected(R"(
-type item = record val: unsigned; end;
-     itemArr = ^array[1..10] of item;
-var p: itemArr;
-begin
-  new(p); p^[1].val:=0; dispose(p);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, PointerToUIntArray) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type uintArr = ^array[1..5] of unsigned;
 var p: uintArr;
 begin
   new(p); p^[5]:=10; dispose(p);
 end.)",
-           default_expected(R"(
-type uintArr = ^array[1..5] of unsigned;
-var p: uintArr;
-begin
-  new(p); p^[5]:=10; dispose(p);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, StructWithMatrix) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type mat = record m: array[1..2,1..2] of longint; end;
 var v: mat;
 begin
   v.m[1,1]:=1;
 end.)",
-           default_expected(R"(
-type mat = record m: array[1..2,1..2] of longint; end;
-var v: mat;
-begin
-  v.m[1,1]:=1;
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, FloatPointer) {
+  std::vector<Token> expected_tokens = tokens({{TT::Var, "var"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 var p:^real;
 begin
   new(p); p^:=3.14; dispose(p);
 end.)",
-           default_expected(R"(
-var p:^real;
-begin
-  new(p); p^:=3.14; dispose(p);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, DynamicStringPointer) {
+  std::vector<Token> expected_tokens = tokens({{TT::Type, "type"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 type sp = ^string;
 var p: sp;
 begin
   new(p); p^:='hi'; dispose(p);
 end.)",
-           default_expected(R"(
-type sp = ^string;
-var p: sp;
-begin
-  new(p); p^:='hi'; dispose(p);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }
 
 TEST(ComplexTests, FibonacciRecursive) {
+  std::vector<Token> expected_tokens = tokens({{TT::Function, "function"}});
+  AST expected_ast = make_empty_ast();
+  std::string expected_asm = "section .text";
+  std::string expected_output = "";
   run_full(R"(
 function fib(n: longint): longint;
 begin
@@ -321,12 +299,5 @@ end;
 begin
   fib(5);
 end.)",
-           default_expected(R"(
-function fib(n: longint): longint;
-begin
-  if n<2 then fib:=n else fib:=fib(n-1)+fib(n-2);
-end;
-begin
-  fib(5);
-end.)"));
+           expected_tokens, expected_ast, expected_asm, expected_output);
 }

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -7,6 +7,7 @@
 #include <cctype>
 #include <gtest/gtest.h>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace test_utils {
@@ -17,6 +18,13 @@ using pascal::Lexer;
 using pascal::Parser;
 using pascal::Token;
 using pascal::TokenType;
+
+inline Token make_token(TokenType type, std::string_view lexeme) {
+  Token tok{};
+  tok.type = type;
+  tok.lexeme = std::string(lexeme);
+  return tok;
+}
 
 inline Token make_token(std::string_view text) {
   Token tok{};
@@ -58,6 +66,10 @@ inline std::vector<Token> naive_tokenize(std::string_view src) {
   return tokens;
 }
 
+inline std::vector<Token> default_tokens(std::string_view src) {
+  return naive_tokenize(src);
+}
+
 inline std::vector<Token>
 tokens(std::initializer_list<std::string_view> lexemes) {
   std::vector<Token> result;
@@ -68,59 +80,114 @@ tokens(std::initializer_list<std::string_view> lexemes) {
   return result;
 }
 
-struct ExpectedResults {
-  std::vector<Token> tokens;
-  AST ast{};
-  std::string asm_code;
-  std::string output;
-};
-
-inline ExpectedResults
-make_expected(std::initializer_list<std::string_view> lexemes,
-              std::string_view asm_code = "section .text",
-              std::string_view output = {}) {
-  ExpectedResults e{};
-  e.tokens = tokens(lexemes);
-  e.ast.valid = true;
-  e.asm_code = std::string(asm_code);
-  e.output = std::string(output);
-  return e;
+inline std::vector<Token>
+tokens(std::initializer_list<std::pair<TokenType, std::string_view>> items) {
+  std::vector<Token> result;
+  for (auto [type, lex] : items) {
+    result.push_back(make_token(type, lex));
+  }
+  result.push_back({TokenType::EndOfFile, ""});
+  return result;
 }
 
 inline std::string execute_stub(std::string_view /*asm_code*/) { return {}; }
 
-inline ExpectedResults default_expected(std::string_view src) {
-  ExpectedResults e{};
-  e.tokens = naive_tokenize(src);
-  e.ast.valid = true;
-  e.asm_code = "section .text";
-  e.output = {};
-  return e;
+inline bool ast_equal_node(const pascal::ASTNode *a, const pascal::ASTNode *b) {
+  if (!a || !b)
+    return a == b;
+  if (a->kind != b->kind)
+    return false;
+  using pascal::NodeKind;
+  switch (a->kind) {
+  case NodeKind::Program: {
+    auto pa = static_cast<const pascal::Program *>(a);
+    auto pb = static_cast<const pascal::Program *>(b);
+    if (pa->name != pb->name)
+      return false;
+    return ast_equal_node(pa->block.get(), pb->block.get());
+  }
+  case NodeKind::Block: {
+    auto ba = static_cast<const pascal::Block *>(a);
+    auto bb = static_cast<const pascal::Block *>(b);
+    if (ba->declarations.size() != bb->declarations.size() ||
+        ba->statements.size() != bb->statements.size())
+      return false;
+    for (size_t i = 0; i < ba->declarations.size(); ++i)
+      if (!ast_equal_node(ba->declarations[i].get(), bb->declarations[i].get()))
+        return false;
+    for (size_t i = 0; i < ba->statements.size(); ++i)
+      if (!ast_equal_node(ba->statements[i].get(), bb->statements[i].get()))
+        return false;
+    return true;
+  }
+  case NodeKind::AssignStmt: {
+    auto aa = static_cast<const pascal::AssignStmt *>(a);
+    auto ab = static_cast<const pascal::AssignStmt *>(b);
+    return ast_equal_node(aa->target.get(), ab->target.get()) &&
+           ast_equal_node(aa->value.get(), ab->value.get());
+  }
+  case NodeKind::BinaryExpr: {
+    auto ba = static_cast<const pascal::BinaryExpr *>(a);
+    auto bb = static_cast<const pascal::BinaryExpr *>(b);
+    return ba->op == bb->op && ast_equal_node(ba->left.get(), bb->left.get()) &&
+           ast_equal_node(ba->right.get(), bb->right.get());
+  }
+  case NodeKind::LiteralExpr: {
+    auto la = static_cast<const pascal::LiteralExpr *>(a);
+    auto lb = static_cast<const pascal::LiteralExpr *>(b);
+    return la->value == lb->value;
+  }
+  case NodeKind::VariableExpr: {
+    auto va = static_cast<const pascal::VariableExpr *>(a);
+    auto vb = static_cast<const pascal::VariableExpr *>(b);
+    if (va->name != vb->name || va->selectors.size() != vb->selectors.size())
+      return false;
+    return true;
+  }
+  default:
+    return true;
+  }
 }
 
-inline void run_full(std::string_view src, const ExpectedResults &expected) {
+inline bool ast_equal(const pascal::AST &a, const pascal::AST &b) {
+  if (a.valid != b.valid)
+    return false;
+  return ast_equal_node(a.root.get(), b.root.get());
+}
+
+inline pascal::AST make_empty_ast(bool valid = true) {
+  pascal::AST ast{};
+  ast.valid = valid;
+  return ast;
+}
+
+inline void run_full(std::string_view src,
+                     const std::vector<Token> &expected_tokens,
+                     const pascal::AST &expected_ast,
+                     std::string_view expected_asm,
+                     std::string_view expected_output) {
   Lexer lex(src);
   auto tokens = lex.scanTokens();
-  ASSERT_EQ(tokens.size(), expected.tokens.size());
+  ASSERT_EQ(tokens.size(), expected_tokens.size());
   for (size_t i = 0; i < tokens.size(); ++i) {
-    EXPECT_EQ(tokens[i].type, expected.tokens[i].type);
-    EXPECT_EQ(tokens[i].lexeme, expected.tokens[i].lexeme);
+    EXPECT_EQ(tokens[i].type, expected_tokens[i].type);
+    EXPECT_EQ(tokens[i].lexeme, expected_tokens[i].lexeme);
   }
 
   Parser parser(tokens);
   AST ast{};
   EXPECT_NO_THROW({ ast = parser.parse(); });
-  EXPECT_EQ(ast.valid, expected.ast.valid);
+  EXPECT_TRUE(ast_equal(ast, expected_ast));
 
   ASTValidator validator;
   EXPECT_TRUE(validator.validate(ast));
 
   CodeGenerator codegen;
   auto asm_code = codegen.generate(ast);
-  EXPECT_EQ(asm_code, expected.asm_code);
+  EXPECT_EQ(asm_code, expected_asm);
 
   auto output = execute_stub(asm_code);
-  EXPECT_EQ(output, expected.output);
+  EXPECT_EQ(output, expected_output);
 }
 
 } // namespace test_utils


### PR DESCRIPTION
## Summary
- add inline constructors for all AST node structures so tests can instantiate nodes
- hardcode expected tokens, AST, assembly, and output in unit tests

## Testing
- `make compiler`
- `make tests` *(fails: 75 FAILED TESTS)*

------
https://chatgpt.com/codex/tasks/task_e_68622db967dc83309733eacf1033fc3b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Pascal language support with richer type representations, including arrays, records, pointers, and dynamic memory operations.
  * Improved variable and parameter declarations to support structured type information.
  * Added new token type for caret (^) character.

* **Refactor**
  * Parser and AST interfaces now use more specific types for improved clarity and type safety.
  * Tests updated to use explicit token and AST expectations, with improved utilities for token and AST comparison.

* **Tests**
  * Refactored test cases for greater precision and maintainability, including new helpers for token creation and AST equality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->