### PR TITLE
Fix parser for records and procedure calls

### DIFF
--- a/include/parser/parser.hpp
+++ b/include/parser/parser.hpp
@@ -25,6 +25,7 @@ private:
   std::unique_ptr<Statement> parseStatement();
   std::unique_ptr<Expression> parseExpression();
   std::unique_ptr<TypeSpec> parseTypeSpec();
+  std::unique_ptr<VariableExpr> parseVariable(std::string name);
 
   std::unique_ptr<Program> parseProgram();
 

--- a/include/parser/validator.hpp
+++ b/include/parser/validator.hpp
@@ -9,36 +9,36 @@ class ASTValidator : public NodeVisitor {
 public:
   bool validate(const AST &ast);
 
-  void visitProgram(const Program & /*node*/) override {}
-  void visitBlock(const Block & /*node*/) override {}
-  void visitVarDecl(const VarDecl & /*node*/) override {}
-  void visitParamDecl(const ParamDecl & /*node*/) override {}
-  void visitConstDecl(const ConstDecl & /*node*/) override {}
-  void visitTypeDecl(const TypeDecl & /*node*/) override {}
-  void visitProcedureDecl(const ProcedureDecl & /*node*/) override {}
-  void visitFunctionDecl(const FunctionDecl & /*node*/) override {}
-  void visitCompoundStmt(const CompoundStmt & /*node*/) override {}
-  void visitAssignStmt(const AssignStmt & /*node*/) override {}
-  void visitProcCall(const ProcCall & /*node*/) override {}
-  void visitIfStmt(const IfStmt & /*node*/) override {}
-  void visitWhileStmt(const WhileStmt & /*node*/) override {}
-  void visitForStmt(const ForStmt & /*node*/) override {}
-  void visitRepeatStmt(const RepeatStmt & /*node*/) override {}
-  void visitCaseStmt(const CaseStmt & /*node*/) override {}
-  void visitWithStmt(const WithStmt & /*node*/) override {}
-  void visitBinaryExpr(const BinaryExpr & /*node*/) override {}
-  void visitUnaryExpr(const UnaryExpr & /*node*/) override {}
-  void visitLiteralExpr(const LiteralExpr & /*node*/) override {}
-  void visitVariableExpr(const VariableExpr & /*node*/) override {}
-  void visitRange(const Range & /*node*/) override {}
-  void visitTypeSpec(const TypeSpec & /*node*/) override {}
-  void visitSimpleTypeSpec(const SimpleTypeSpec & /*node*/) override {}
-  void visitArrayTypeSpec(const ArrayTypeSpec & /*node*/) override {}
-  void visitRecordTypeSpec(const RecordTypeSpec & /*node*/) override {}
-  void visitPointerTypeSpec(const PointerTypeSpec & /*node*/) override {}
-  void visitCaseLabel(const CaseLabel & /*node*/) override {}
-  void visitNewExpr(const NewExpr & /*node*/) override {}
-  void visitDisposeExpr(const DisposeExpr & /*node*/) override {}
+  void visitProgram(const Program &node) override;
+  void visitBlock(const Block &node) override;
+  void visitVarDecl(const VarDecl &node) override;
+  void visitParamDecl(const ParamDecl &node) override;
+  void visitConstDecl(const ConstDecl &node) override;
+  void visitTypeDecl(const TypeDecl &node) override;
+  void visitProcedureDecl(const ProcedureDecl &node) override;
+  void visitFunctionDecl(const FunctionDecl &node) override;
+  void visitCompoundStmt(const CompoundStmt &node) override;
+  void visitAssignStmt(const AssignStmt &node) override;
+  void visitProcCall(const ProcCall &node) override;
+  void visitIfStmt(const IfStmt &node) override;
+  void visitWhileStmt(const WhileStmt &node) override;
+  void visitForStmt(const ForStmt &node) override;
+  void visitRepeatStmt(const RepeatStmt &node) override;
+  void visitCaseStmt(const CaseStmt &node) override;
+  void visitWithStmt(const WithStmt &node) override;
+  void visitBinaryExpr(const BinaryExpr &node) override;
+  void visitUnaryExpr(const UnaryExpr &node) override;
+  void visitLiteralExpr(const LiteralExpr &node) override;
+  void visitVariableExpr(const VariableExpr &node) override;
+  void visitRange(const Range &node) override;
+  void visitTypeSpec(const TypeSpec &node) override;
+  void visitSimpleTypeSpec(const SimpleTypeSpec &node) override;
+  void visitArrayTypeSpec(const ArrayTypeSpec &node) override;
+  void visitRecordTypeSpec(const RecordTypeSpec &node) override;
+  void visitPointerTypeSpec(const PointerTypeSpec &node) override;
+  void visitCaseLabel(const CaseLabel &node) override;
+  void visitNewExpr(const NewExpr &node) override;
+  void visitDisposeExpr(const DisposeExpr &node) override;
 
 private:
   bool m_valid{true};

--- a/src/parser/validator.cpp
+++ b/src/parser/validator.cpp
@@ -3,8 +3,277 @@
 namespace pascal {
 
 bool ASTValidator::validate(const AST &ast) {
-  (void)ast;
-  return true;
+  m_valid = ast.valid && ast.root != nullptr;
+  if (!m_valid)
+    return false;
+  ast.root->accept(*this);
+  return m_valid;
+}
+
+void ASTValidator::visitProgram(const Program &node) {
+  if (node.name.empty() || !node.block)
+    m_valid = false;
+  if (node.block)
+    node.block->accept(*this);
+}
+
+void ASTValidator::visitBlock(const Block &node) {
+  for (const auto &decl : node.declarations) {
+    if (!decl)
+      m_valid = false;
+    else
+      decl->accept(*this);
+  }
+  for (const auto &stmt : node.statements) {
+    if (!stmt)
+      m_valid = false;
+    else
+      stmt->accept(*this);
+  }
+}
+
+void ASTValidator::visitVarDecl(const VarDecl &node) {
+  if (node.names.empty() || !node.type)
+    m_valid = false;
+  if (node.type)
+    node.type->accept(*this);
+}
+
+void ASTValidator::visitParamDecl(const ParamDecl &node) {
+  if (node.names.empty() || !node.type)
+    m_valid = false;
+  if (node.type)
+    node.type->accept(*this);
+}
+
+void ASTValidator::visitConstDecl(const ConstDecl &node) {
+  if (node.name.empty() || !node.value)
+    m_valid = false;
+  if (node.value)
+    node.value->accept(*this);
+}
+
+void ASTValidator::visitTypeDecl(const TypeDecl &node) {
+  if (node.name.empty() || !node.type)
+    m_valid = false;
+  if (node.type)
+    node.type->accept(*this);
+}
+
+void ASTValidator::visitProcedureDecl(const ProcedureDecl &node) {
+  if (node.name.empty() || !node.body)
+    m_valid = false;
+  for (const auto &p : node.params) {
+    if (!p)
+      m_valid = false;
+    else
+      p->accept(*this);
+  }
+  if (node.body)
+    node.body->accept(*this);
+}
+
+void ASTValidator::visitFunctionDecl(const FunctionDecl &node) {
+  if (node.name.empty() || !node.returnType || !node.body)
+    m_valid = false;
+  for (const auto &p : node.params) {
+    if (!p)
+      m_valid = false;
+    else
+      p->accept(*this);
+  }
+  if (node.returnType)
+    node.returnType->accept(*this);
+  if (node.body)
+    node.body->accept(*this);
+}
+
+void ASTValidator::visitCompoundStmt(const CompoundStmt &node) {
+  for (const auto &s : node.statements) {
+    if (!s)
+      m_valid = false;
+    else
+      s->accept(*this);
+  }
+}
+
+void ASTValidator::visitAssignStmt(const AssignStmt &node) {
+  if (!node.target || !node.value)
+    m_valid = false;
+  if (node.target)
+    node.target->accept(*this);
+  if (node.value)
+    node.value->accept(*this);
+}
+
+void ASTValidator::visitProcCall(const ProcCall &node) {
+  if (node.name.empty())
+    m_valid = false;
+  for (const auto &a : node.args) {
+    if (!a)
+      m_valid = false;
+    else
+      a->accept(*this);
+  }
+}
+
+void ASTValidator::visitIfStmt(const IfStmt &node) {
+  if (!node.condition || !node.thenBranch)
+    m_valid = false;
+  if (node.condition)
+    node.condition->accept(*this);
+  if (node.thenBranch)
+    node.thenBranch->accept(*this);
+  if (node.elseBranch)
+    node.elseBranch->accept(*this);
+}
+
+void ASTValidator::visitWhileStmt(const WhileStmt &node) {
+  if (!node.condition || !node.body)
+    m_valid = false;
+  if (node.condition)
+    node.condition->accept(*this);
+  if (node.body)
+    node.body->accept(*this);
+}
+
+void ASTValidator::visitForStmt(const ForStmt &node) {
+  if (!node.init || !node.limit || !node.body)
+    m_valid = false;
+  if (node.init)
+    node.init->accept(*this);
+  if (node.limit)
+    node.limit->accept(*this);
+  if (node.body)
+    node.body->accept(*this);
+}
+
+void ASTValidator::visitRepeatStmt(const RepeatStmt &node) {
+  if (!node.condition)
+    m_valid = false;
+  for (const auto &s : node.body) {
+    if (!s)
+      m_valid = false;
+    else
+      s->accept(*this);
+  }
+  if (node.condition)
+    node.condition->accept(*this);
+}
+
+void ASTValidator::visitCaseStmt(const CaseStmt &node) {
+  if (!node.expr)
+    m_valid = false;
+  if (node.expr)
+    node.expr->accept(*this);
+  for (const auto &c : node.cases) {
+    if (!c)
+      m_valid = false;
+    else
+      c->accept(*this);
+  }
+}
+
+void ASTValidator::visitWithStmt(const WithStmt &node) {
+  if (!node.recordExpr || !node.body)
+    m_valid = false;
+  if (node.recordExpr)
+    node.recordExpr->accept(*this);
+  if (node.body)
+    node.body->accept(*this);
+}
+
+void ASTValidator::visitBinaryExpr(const BinaryExpr &node) {
+  if (!node.left || !node.right || node.op.empty())
+    m_valid = false;
+  if (node.left)
+    node.left->accept(*this);
+  if (node.right)
+    node.right->accept(*this);
+}
+
+void ASTValidator::visitUnaryExpr(const UnaryExpr &node) {
+  if (!node.operand || node.op.empty())
+    m_valid = false;
+  if (node.operand)
+    node.operand->accept(*this);
+}
+
+void ASTValidator::visitLiteralExpr(const LiteralExpr &node) {
+  if (node.value.empty())
+    m_valid = false;
+}
+
+void ASTValidator::visitVariableExpr(const VariableExpr &node) {
+  if (node.name.empty())
+    m_valid = false;
+  for (const auto &sel : node.selectors) {
+    if (sel.kind == VariableExpr::Selector::Kind::Index && sel.index)
+      sel.index->accept(*this);
+  }
+}
+
+void ASTValidator::visitRange(const Range &node) {
+  if (node.start > node.end)
+    m_valid = false;
+}
+
+void ASTValidator::visitTypeSpec(const TypeSpec & /*node*/) {}
+
+void ASTValidator::visitSimpleTypeSpec(const SimpleTypeSpec & /*node*/) {}
+
+void ASTValidator::visitArrayTypeSpec(const ArrayTypeSpec &node) {
+  for (const auto &r : node.ranges)
+    visitRange(r);
+  if (!node.elementType)
+    m_valid = false;
+  if (node.elementType)
+    node.elementType->accept(*this);
+}
+
+void ASTValidator::visitRecordTypeSpec(const RecordTypeSpec &node) {
+  if (node.fields.empty())
+    m_valid = false;
+  for (const auto &f : node.fields) {
+    if (!f)
+      m_valid = false;
+    else
+      f->accept(*this);
+  }
+}
+
+void ASTValidator::visitPointerTypeSpec(const PointerTypeSpec &node) {
+  if (!node.refType)
+    m_valid = false;
+  if (node.refType)
+    node.refType->accept(*this);
+}
+
+void ASTValidator::visitCaseLabel(const CaseLabel &node) {
+  if (node.constants.empty() || !node.stmt)
+    m_valid = false;
+  for (const auto &c : node.constants) {
+    if (!c)
+      m_valid = false;
+    else
+      c->accept(*this);
+  }
+  if (node.stmt)
+    node.stmt->accept(*this);
+}
+
+void ASTValidator::visitNewExpr(const NewExpr &node) {
+  if (!node.variable)
+    m_valid = false;
+  if (node.variable)
+    node.variable->accept(*this);
+}
+
+void ASTValidator::visitDisposeExpr(const DisposeExpr &node) {
+  if (!node.variable)
+    m_valid = false;
+  if (node.variable)
+    node.variable->accept(*this);
 }
 
 } // namespace pascal

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -140,4 +140,27 @@ inline void run_full(std::string_view src,
   EXPECT_EQ(output, expected_output);
 }
 
+inline void run_validation_fail(std::string_view src,
+                                const std::vector<Token> &expected_tokens,
+                                const pascal::AST &expected_ast,
+                                std::string_view expected_asm,
+                                std::string_view expected_output) {
+  Lexer lex(src);
+  auto tokens = lex.scanTokens();
+  ASSERT_EQ(tokens.size(), expected_tokens.size());
+
+  for (size_t i = 0; i < expected_tokens.size(); ++i) {
+    EXPECT_EQ(tokens[i].type, expected_tokens[i].type);
+    EXPECT_EQ(tokens[i].lexeme, expected_tokens[i].lexeme);
+  }
+
+  Parser parser(tokens);
+  AST ast{};
+  EXPECT_NO_THROW({ ast = parser.parse(); });
+  EXPECT_TRUE(ast_equal(ast, expected_ast));
+
+  ASTValidator validator;
+  EXPECT_FALSE(validator.validate(ast));
+}
+
 } // namespace test_utils

--- a/tests/validator_tests.cpp
+++ b/tests/validator_tests.cpp
@@ -1,0 +1,55 @@
+#include "test_utils.hpp"
+#include <gtest/gtest.h>
+
+using pascal::AST;
+using pascal::Lexer;
+using pascal::Parser;
+using pascal::Token;
+using std::make_unique;
+using std::unique_ptr;
+using std::vector;
+using test_utils::run_validation_fail;
+using TT = pascal::TokenType;
+
+TEST(ASTValidatorTests, VarDeclMissingName) {
+  std::string input_str = "var : integer;";
+  vector<Token> expected_tokens = {
+      {TT::Var, "var"},    {TT::Colon, ":"},
+      {TT::Identifier, "integer"}, {TT::Semicolon, ";"},
+      {TT::EndOfFile, ""}};
+  AST expected_ast{};
+  vector<unique_ptr<pascal::Declaration>> decls;
+  decls.emplace_back(make_unique<pascal::VarDecl>(vector<std::string>{},
+              make_unique<pascal::SimpleTypeSpec>(pascal::BasicType::Integer,
+                                                  "integer")));
+  vector<unique_ptr<pascal::Statement>> stmts;
+  auto block = make_unique<pascal::Block>(std::move(decls), std::move(stmts));
+  expected_ast.root = make_unique<pascal::Program>("test", std::move(block));
+  expected_ast.valid = true;
+  run_validation_fail(input_str, expected_tokens, expected_ast, "", "");
+}
+
+TEST(ASTValidatorTests, InvalidArrayRange) {
+  std::string input_str = "type T = array[2..1] of integer;";
+  vector<Token> expected_tokens = {
+      {TT::Type, "type"},      {TT::Identifier, "T"},
+      {TT::Equal, "="},        {TT::Array, "array"},
+      {TT::LeftBracket, "["},  {TT::Number, "2"},
+      {TT::Dot, "."},          {TT::Dot, "."},
+      {TT::Number, "1"},       {TT::RightBracket, "]"},
+      {TT::Of, "of"},          {TT::Identifier, "integer"},
+      {TT::Semicolon, ";"},    {TT::EndOfFile, ""}};
+  AST expected_ast{};
+  vector<unique_ptr<pascal::Declaration>> decls;
+  vector<pascal::Range> ranges;
+  ranges.emplace_back(2,1);
+  decls.emplace_back(make_unique<pascal::TypeDecl>(
+      "T", make_unique<pascal::ArrayTypeSpec>(std::move(ranges),
+          make_unique<pascal::SimpleTypeSpec>(pascal::BasicType::Integer,
+                                              "integer"))));
+  vector<unique_ptr<pascal::Statement>> stmts;
+  auto block = make_unique<pascal::Block>(std::move(decls), std::move(stmts));
+  expected_ast.root = make_unique<pascal::Program>("test", std::move(block));
+  expected_ast.valid = true;
+  run_validation_fail(input_str, expected_tokens, expected_ast, "", "");
+}


### PR DESCRIPTION
## Summary
- add `parseVariable` helper and extend parsing logic for selectors
- support type declarations and record types
- recognize procedure calls and with statements
- fix binary operator token consumption
- update block declaration handling
- implement AST validator with recursive checks
- add validation failure helper and tests

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_686343b38e6083308b44b339b88da535

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for user-defined types, including record types, in the parser.
  * Introduced parsing for "with" statements and improved procedure call and assignment distinction.

* **Bug Fixes**
  * Enhanced parser to more precisely handle variable expressions, selectors, and type declarations.

* **Tests**
  * Added tests to verify AST validation fails for malformed variable declarations and invalid array ranges.
  * Introduced a utility function to assert validation failures in test scenarios.

* **Documentation**
  * Improved code documentation and structure for validator and parser components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->