### PR TITLE
Add Docker build for API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:22.04
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        cmake \
+        libboost-all-dev \
+        libssl-dev \
+        zlib1g-dev \
+        libasio-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Crow (header-only library)
+RUN git clone https://github.com/CrowCpp/Crow.git /tmp/crow \
+    && cp -r /tmp/crow/include/crow /usr/local/include/ \
+    && rm -rf /tmp/crow
+
+COPY . .
+
+RUN make api
+
+EXPOSE 443
+
+CMD ["./build/api"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,24 @@ make clean  # removes build artefacts
 
 The resulting binary is placed in `build/compiler`.
 
+## Docker
+
+A `Dockerfile` is provided to build and run the API version of the compiler.
+Build the image with:
+
+```bash
+docker build -t pascal-api .
+```
+
+Then run the container exposing port 443:
+
+```bash
+docker run -p 443:443 pascal-api
+```
+
+The API serves the `/compile` endpoint which returns a JSON object matching the
+`CompilationResult` interface described in the project documentation.
+
 ## Using the Compiler
 
 Once built, invoke the compiler with a Pascal source file:


### PR DESCRIPTION
## Summary
- add Dockerfile to build and run the API executable
- document Docker usage in README

## Testing
- `./build/tests`

------
https://chatgpt.com/codex/tasks/task_e_68635a55fe5083308ef4ae59e97985ed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker support for the API, allowing users to build and run the application in a containerized environment.
* **Documentation**
  * Updated the README with instructions on building and running the Docker image, including usage details for the API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->