### PR TITLE
Improve ASTValidator feedback

### DIFF
--- a/include/parser/ast.hpp
+++ b/include/parser/ast.hpp
@@ -114,11 +114,14 @@ struct ASTNode {
   ASTNode(ASTNode &&) = delete;
   ASTNode &operator=(const ASTNode &) = default;
   ASTNode &operator=(ASTNode &&) = delete;
-  explicit ASTNode(NodeKind k) : kind(k) {}
+  explicit ASTNode(NodeKind k, std::size_t l = 0, std::size_t c = 0)
+      : kind(k), line(l), column(c) {}
   virtual ~ASTNode();
   virtual void accept(NodeVisitor &v) const = 0;
 
   NodeKind kind;
+  std::size_t line{0};
+  std::size_t column{0};
 };
 
 struct Expression : ASTNode {

--- a/include/parser/validator.hpp
+++ b/include/parser/validator.hpp
@@ -7,7 +7,14 @@ namespace pascal {
 
 class ASTValidator : public NodeVisitor {
 public:
-  bool validate(const AST &ast);
+  struct Result {
+    bool success{true};
+    std::string message{};
+    std::size_t line{0};
+    std::size_t column{0};
+  };
+
+  Result validate(const AST &ast);
 
   void visitProgram(const Program &node) override;
   void visitBlock(const Block &node) override;
@@ -42,6 +49,10 @@ public:
 
 private:
   bool m_valid{true};
+  void setError(const std::string &msg, const ASTNode &node);
+  std::string m_errorMsg{};
+  std::size_t m_errorLine{0};
+  std::size_t m_errorColumn{0};
 };
 
 } // namespace pascal

--- a/tests/compiler_tests.cpp
+++ b/tests/compiler_tests.cpp
@@ -900,9 +900,9 @@ TEST(FunctionTests, Func2) {
 }
 
 TEST(FunctionTests, Func3) {
-  std::string input_str = "function g(x: integer): integer; begin g:=x;
-      end;
-  "; std::vector<Token> expected_tokens = {{TT::Function, " function "},
+  std::string input_str =
+      "function g(x: integer): integer; begin g:=x; end;";
+  std::vector<Token> expected_tokens = {{TT::Function, "function"},
       {TT::Identifier, "g"},
       {TT::LeftParen, "("}, {TT::Identifier, "x"}, {TT::Colon, ":"},
       {TT::Identifier, "integer"}, {TT::RightParen, ")"}, {TT::Colon, ":"},

--- a/tests/test_utils.hpp
+++ b/tests/test_utils.hpp
@@ -119,7 +119,8 @@ inline void run_full(std::string_view src,
     return;
 
   ASTValidator validator;
-  EXPECT_TRUE(validator.validate(ast));
+  auto res = validator.validate(ast);
+  EXPECT_TRUE(res.success) << res.message;
 
   CodeGenerator codegen;
   auto asm_code = codegen.generate(ast);
@@ -153,7 +154,8 @@ run_validation_fail(std::string_view src,
   EXPECT_TRUE(ast_equal(ast, expected_ast));
 
   ASTValidator validator;
-  EXPECT_FALSE(validator.validate(ast));
+  auto res = validator.validate(ast);
+  EXPECT_FALSE(res.success);
 }
 
 } // namespace test_utils


### PR DESCRIPTION
## Summary
- extend AST nodes with line and column information
- add detailed error info to ASTValidator with new `Result` type
- propagate node location data during parsing
- report validation errors with messages and source positions
- adjust tests and API to use the updated validator
- refactor API endpoint to return detailed `CompilationResult` object
- fix missing quote in `Func3` test

## Testing
- `make compiler`
- `make tests` *(fails: 50 test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6863694a585c8330ab39a994e679ef61