### PR TITLE
Enable CORS for web API

### DIFF
--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,5 +1,6 @@
 #include <crow/app.h>
 #include <crow/common.h>
+#include <crow/middlewares/cors.h>
 
 #include "executor/executor.hpp"
 #include "parser/parser.hpp"
@@ -137,7 +138,11 @@ std::string tokenTypeToString(pascal::TokenType type) {
 } // namespace
 
 auto main(int /*argc*/, char* /*argv*/[]) -> int {
-  crow::SimpleApp app;
+  crow::App<crow::CORSHandler> app;
+  auto& cors = app.get_middleware<crow::CORSHandler>();
+  cors.global()
+      .methods("GET"_method, "POST"_method, "OPTIONS"_method)
+      .headers("Content-Type");
 
   // Health check endpoint used by CI or clients.
   CROW_ROUTE(app, "/health")([] { return "Hello world"; });


### PR DESCRIPTION
## Summary
- allow cross-origin requests in API server using Crow's CORS middleware

## Testing
- `make api`
- `cd tests && ./run_tests.sh` *(fails: 50 FAILED TESTS)*

------
https://chatgpt.com/codex/tasks/task_e_686375ccc2b48330941d96b975fb5d98