### PR TITLE
Add CLI implementation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,9 +1,54 @@
+#include "executor/executor.hpp"
 #include "parser/parser.hpp"
+#include "parser/validator.hpp"
 #include "scanner/lexer.hpp"
 #include "visitors/codegen.hpp"
-#include <iostream>
 
-int main(int /*argc*/, char ** /*argv*/) {
-  std::cout << "Pascal compiler (C++23) stub" << std::endl;
+#include <fstream>
+#include <iostream>
+#include <iterator>
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr << "Usage: " << argv[0] << " <file>" << std::endl;
+    return 1;
+  }
+
+  std::ifstream in(argv[1]);
+  if (!in) {
+    std::cerr << "Failed to open file: " << argv[1] << std::endl;
+    return 1;
+  }
+
+  std::string source((std::istreambuf_iterator<char>(in)),
+                     std::istreambuf_iterator<char>());
+
+  pascal::Lexer lexer(source);
+  auto tokens = lexer.scanTokens();
+
+  pascal::Parser parser(tokens);
+  pascal::AST ast = parser.parse();
+  if (!ast.valid || !ast.root) {
+    std::cerr << "Parsing failed" << std::endl;
+    return 1;
+  }
+
+  pascal::ASTValidator validator;
+  auto res = validator.validate(ast);
+  if (!res.success) {
+    std::cerr << res.message;
+    if (res.line || res.column)
+      std::cerr << " at " << res.line << ':' << res.column;
+    std::cerr << std::endl;
+    return 1;
+  }
+
+  pascal::CodeGenerator codegen;
+  std::string asm_code = codegen.generate(ast);
+
+  pascal::Executor exec;
+  std::string output = exec.run(asm_code);
+
+  std::cout << output;
   return 0;
 }


### PR DESCRIPTION
## Summary
- implement `main` as a command line interface
- run lexing, parsing, validation, codegen and execution on a file

## Testing
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_6863beffd360833093c172c9e2d974b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full support for compiling and executing Pascal source files provided via command-line, including detailed error reporting at each stage.
  * Outputs the result of the executed Pascal program directly to standard output.

* **Bug Fixes**
  * Improved error handling to provide clear messages and early termination when issues are encountered during compilation or execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->