### PR TITLE
Fix function tests to include full programs

### DIFF
--- a/tests/function_tests.cpp
+++ b/tests/function_tests.cpp
@@ -1,13 +1,19 @@
 #include "test_common.hpp"
 
 TEST(FunctionTests, Func1) {
-  std::string input_str = "function f: integer; begin f:=0; end;";
+  std::string input_str =
+      "program test; function f: integer; begin f:=0; end; begin end.";
   std::vector<Token> expected_tokens = {
-      {TT::Function, "function"},  {TT::Identifier, "f"}, {TT::Colon, ":"},
-      {TT::Identifier, "integer"}, {TT::Semicolon, ";"},  {TT::Begin, "begin"},
-      {TT::Identifier, "f"},       {TT::Colon, ":"},      {TT::Assign, "="},
-      {TT::Number, "0"},           {TT::Semicolon, ";"},  {TT::End, "end"},
-      {TT::Semicolon, ";"},        {TT::EndOfFile, ""}};
+      {TT::Program, "program"},  {TT::Identifier, "test"},
+      {TT::Semicolon, ";"},      {TT::Function, "function"},
+      {TT::Identifier, "f"},      {TT::Colon, ":"},
+      {TT::Identifier, "integer"}, {TT::Semicolon, ";"},
+      {TT::Begin, "begin"},       {TT::Identifier, "f"},
+      {TT::Colon, ":"},           {TT::Assign, "="},
+      {TT::Number, "0"},          {TT::Semicolon, ";"},
+      {TT::End, "end"},           {TT::Semicolon, ";"},
+      {TT::Begin, "begin"},       {TT::End, "end"},
+      {TT::Dot, "."},             {TT::EndOfFile, ""}};
   AST expected_ast{};
 
   std::vector<std::unique_ptr<pascal::Declaration>> decls;
@@ -43,10 +49,15 @@ TEST(FunctionTests, Func1) {
 }
 
 TEST(FunctionTests, Func2) {
-  std::string input_str = "procedure p; begin end;";
+  std::string input_str =
+      "program test; procedure p; begin end; begin end.";
   std::vector<Token> expected_tokens = {
-      {TT::Procedure, "procedure"}, {TT::Identifier, "p"}, {TT::Semicolon, ";"},
-      {TT::Begin, "begin"},         {TT::End, "end"},      {TT::Semicolon, ";"},
+      {TT::Program, "program"},    {TT::Identifier, "test"},
+      {TT::Semicolon, ";"},       {TT::Procedure, "procedure"},
+      {TT::Identifier, "p"},       {TT::Semicolon, ";"},
+      {TT::Begin, "begin"},        {TT::End, "end"},
+      {TT::Semicolon, ";"},       {TT::Begin, "begin"},
+      {TT::End, "end"},            {TT::Dot, "."},
       {TT::EndOfFile, ""}};
   AST expected_ast{};
 
@@ -76,26 +87,22 @@ TEST(FunctionTests, Func2) {
 }
 
 TEST(FunctionTests, Func3) {
-  std::string input_str = "function g(x: integer): integer; begin g:=x; end;";
-  std::vector<Token> expected_tokens = {{TT::Function, "function"},
-                                        {TT::Identifier, "g"},
-                                        {TT::LeftParen, "("},
-                                        {TT::Identifier, "x"},
-                                        {TT::Colon, ":"},
-                                        {TT::Identifier, "integer"},
-                                        {TT::RightParen, ")"},
-                                        {TT::Colon, ":"},
-                                        {TT::Identifier, "integer"},
-                                        {TT::Semicolon, ";"},
-                                        {TT::Begin, "begin"},
-                                        {TT::Identifier, "g"},
-                                        {TT::Colon, ":"},
-                                        {TT::Assign, "="},
-                                        {TT::Identifier, "x"},
-                                        {TT::Semicolon, ";"},
-                                        {TT::End, "end"},
-                                        {TT::Semicolon, ";"},
-                                        {TT::EndOfFile, ""}};
+  std::string input_str =
+      "program test; function g(x: integer): integer; begin g:=x; end; begin end.";
+  std::vector<Token> expected_tokens = {
+      {TT::Program, "program"},   {TT::Identifier, "test"},
+      {TT::Semicolon, ";"},      {TT::Function, "function"},
+      {TT::Identifier, "g"},      {TT::LeftParen, "("},
+      {TT::Identifier, "x"},      {TT::Colon, ":"},
+      {TT::Identifier, "integer"}, {TT::RightParen, ")"},
+      {TT::Colon, ":"},           {TT::Identifier, "integer"},
+      {TT::Semicolon, ";"},       {TT::Begin, "begin"},
+      {TT::Identifier, "g"},      {TT::Colon, ":"},
+      {TT::Assign, "="},          {TT::Identifier, "x"},
+      {TT::Semicolon, ";"},       {TT::End, "end"},
+      {TT::Semicolon, ";"},       {TT::Begin, "begin"},
+      {TT::End, "end"},           {TT::Dot, "."},
+      {TT::EndOfFile, ""}};
   AST expected_ast{};
 
   std::vector<std::unique_ptr<pascal::Declaration>> decls;


### PR DESCRIPTION
## Summary
- update `function_tests.cpp` so each test uses a valid Pascal program
- adjust expected token sequences accordingly

## Testing
- `make tests FILE=function_tests.cpp` *(fails: FunctionTests.Func1, FunctionTests.Func2, FunctionTests.Func3)*

------
https://chatgpt.com/codex/tasks/task_e_6863d68f1b288330bb7839ce78aeab23