### PR TITLE
Clean up unused variable in dynamic test

### DIFF
--- a/tests/dynamic_tests.cpp
+++ b/tests/dynamic_tests.cpp
@@ -151,8 +151,6 @@ TEST(DynamicTests, Dyn5) {
   std::vector<std::unique_ptr<pascal::Declaration>> decls;
   std::vector<std::unique_ptr<pascal::Statement>> stmts;
   {
-    std::vector<std::unique_ptr<pascal::Expression>> condArgs;
-    condArgs.emplace_back(std::make_unique<pascal::VariableExpr>("p"));
     auto neq = std::make_unique<pascal::BinaryExpr>(
         std::make_unique<pascal::VariableExpr>("p"), "<>",
         std::make_unique<pascal::VariableExpr>("nil"));


### PR DESCRIPTION
## Summary
- tidy up DynamicTests by removing an unused variable in Dyn5

## Testing
- `make tests FILE=dynamic_tests.cpp` *(fails: Invalid AST)*

------
https://chatgpt.com/codex/tasks/task_e_6863d672c76c8330ace1a7d926ad5f65