### PR TITLE
Fix print tests

### DIFF
--- a/tests/print_tests.cpp
+++ b/tests/print_tests.cpp
@@ -1,11 +1,18 @@
 #include "test_common.hpp"
 
 TEST(PrintTests, PrintString) {
-  std::string input_str = "writeln('hello');";
+  std::string input_str = "program test; "
+                          "begin "
+                          "writeln('hello'); "
+                          "end.";
   std::vector<Token> expected_tokens = {
-      {TT::Identifier, "writeln"}, {TT::LeftParen, "("},  {TT::Identifier, "'"},
-      {TT::Identifier, "hello"},   {TT::Identifier, "'"}, {TT::RightParen, ")"},
-      {TT::Semicolon, ";"},        {TT::EndOfFile, ""}};
+      {TT::Program, "program"},  {TT::Identifier, "test"},
+      {TT::Semicolon, ";"},      {TT::Begin, "begin"},
+      {TT::Identifier, "writeln"}, {TT::LeftParen, "("},
+      {TT::Identifier, "'"},      {TT::Identifier, "hello"},
+      {TT::Identifier, "'"},      {TT::RightParen, ")"},
+      {TT::Semicolon, ";"},      {TT::End, "end"},
+      {TT::Dot, "."},            {TT::EndOfFile, ""}};
   AST expected_ast{};
 
   std::vector<std::unique_ptr<pascal::Declaration>> decls;
@@ -30,6 +37,7 @@ TEST(PrintTests, PrintString) {
                              "global main\n"
                              "main:\n"
                              "    mov    rdi, str0\n"
+                             "    call   puts\n"
                              "    ret\n";
   std::string expected_output = "hello\n";
   run_full(input_str, expected_tokens, expected_ast, expected_asm,
@@ -37,10 +45,17 @@ TEST(PrintTests, PrintString) {
 }
 
 TEST(PrintTests, PrintIntLiteral) {
-  std::string input_str = "writeln(123);";
+  std::string input_str = "program test; "
+                          "begin "
+                          "writeln(123); "
+                          "end.";
   std::vector<Token> expected_tokens = {
-      {TT::Identifier, "writeln"}, {TT::LeftParen, "("}, {TT::Number, "123"},
-      {TT::RightParen, ")"},       {TT::Semicolon, ";"}, {TT::EndOfFile, ""}};
+      {TT::Program, "program"},  {TT::Identifier, "test"},
+      {TT::Semicolon, ";"},      {TT::Begin, "begin"},
+      {TT::Identifier, "writeln"}, {TT::LeftParen, "("},
+      {TT::Number, "123"},       {TT::RightParen, ")"},
+      {TT::Semicolon, ";"},      {TT::End, "end"},
+      {TT::Dot, "."},            {TT::EndOfFile, ""}};
   AST expected_ast{};
 
   // build the proc-call arguments by moving into a vector
@@ -76,12 +91,18 @@ TEST(PrintTests, PrintIntLiteral) {
 }
 
 TEST(PrintTests, PrintIntExpr) {
-  std::string input_str = "writeln(10+20);";
+  std::string input_str = "program test; "
+                          "begin "
+                          "writeln(10+20); "
+                          "end.";
   std::vector<Token> expected_tokens = {
+      {TT::Program, "program"},  {TT::Identifier, "test"},
+      {TT::Semicolon, ";"},      {TT::Begin, "begin"},
       {TT::Identifier, "writeln"}, {TT::LeftParen, "("},
-      {TT::Number, "10"},          {TT::Plus, "+"},
-      {TT::Number, "20"},          {TT::RightParen, ")"},
-      {TT::Semicolon, ";"},        {TT::EndOfFile, ""}};
+      {TT::Number, "10"},         {TT::Plus, "+"},
+      {TT::Number, "20"},         {TT::RightParen, ")"},
+      {TT::Semicolon, ";"},      {TT::End, "end"},
+      {TT::Dot, "."},            {TT::EndOfFile, ""}};
   AST expected_ast{};
 
   // build the expression argument in a vector


### PR DESCRIPTION
## Summary
- ensure print test programs are valid Pascal programs
- update expected tokens for print tests
- correct expected assembly for string printing

## Testing
- `make tests FILE=print_tests.cpp` *(fails: relocation errors when linking nasm output)*

------
https://chatgpt.com/codex/tasks/task_e_68690e8856fc83308c2bbd363c821ee8