### PR TITLE
Fix heap allocation for record pointers

### DIFF
--- a/include/visitors/codegen.hpp
+++ b/include/visitors/codegen.hpp
@@ -56,6 +56,8 @@ private:
   std::string addString(const std::string &value);
   std::string makeLabel();
 
+  size_t typeSize(const TypeSpec *type) const;
+
   std::string m_output;
   std::vector<std::pair<std::string, size_t>> m_vars;
   std::unordered_set<std::string> m_varSet;
@@ -63,6 +65,8 @@ private:
   std::unordered_map<std::string, std::string> m_paramMap;
   std::unordered_map<std::string, std::string> m_stringMap;
   std::vector<std::pair<std::string, std::string>> m_strings;
+  std::unordered_map<std::string, const TypeSpec *> m_typeDefs;
+  std::unordered_map<std::string, size_t> m_ptrSizes;
   std::string m_currentFunction;
   bool m_needMalloc{false};
   bool m_needFree{false};


### PR DESCRIPTION
## Summary
- track pointer base sizes during variable collection
- store type definitions for custom types
- allocate correct byte count when calling `new`

## Testing
- `make tests FILE=invalid_code_tests.cpp` *(fails: AddressSanitizer heap-buffer-overflow)*

------
https://chatgpt.com/codex/tasks/task_e_68691c8f4eb8833090bc9b15046c0434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved memory allocation for pointer variables by accurately calculating and using the size of referenced types during code generation.
  
* **Bug Fixes**
  * Ensured that memory allocation for pointer variables now matches the actual size of the referenced type, rather than using a fixed size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->